### PR TITLE
chore(typegen): move and reimplement type override spec configuration

### DIFF
--- a/generators/typegen/generator.go
+++ b/generators/typegen/generator.go
@@ -71,6 +71,7 @@ func (g *Generator) generateTypesForPackage(s *schema.Schema, genConfig *config.
 
 	var structsForGen []goStruct
 	var enumsForGen []goEnum
+	var err error
 
 	for _, t := range *expandedTypes {
 		switch t.Kind {
@@ -87,9 +88,9 @@ func (g *Generator) generateTypesForPackage(s *schema.Schema, genConfig *config.
 
 			fieldErrs := []error{}
 			for _, f := range fields {
-				typeName, _, err := f.Type.GetType()
+				var typeName string
+				typeName, err = f.GetTypeNameWithOverride(pkgConfig)
 				if err != nil {
-					log.Error(err)
 					fieldErrs = append(fieldErrs, err)
 				}
 
@@ -139,8 +140,8 @@ func (g *Generator) generateTypesForPackage(s *schema.Schema, genConfig *config.
 		destinationPath = pkgConfig.Path
 	}
 
-	if _, err := os.Stat(destinationPath); os.IsNotExist(err) {
-		if err := os.Mkdir(destinationPath, 0755); err != nil {
+	if _, err = os.Stat(destinationPath); os.IsNotExist(err) {
+		if err = os.Mkdir(destinationPath, 0755); err != nil {
 			log.Error(err)
 		}
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -6,8 +6,6 @@ import (
 
 	log "github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v2"
-
-	"github.com/newrelic/tutone/internal/schema"
 )
 
 // Config is the information keeper for generating go structs from type names.
@@ -45,9 +43,9 @@ type CacheConfig struct {
 
 // PackageConfig is the information about a single package, which types to include from the schema, and which generators to use for this package.
 type PackageConfig struct {
-	Name  string            `yaml:"name,omitempty"`
-	Path  string            `yaml:"path,omitempty"`
-	Types []schema.TypeInfo `yaml:"types,omitempty"`
+	Name  string       `yaml:"name,omitempty"`
+	Path  string       `yaml:"path,omitempty"`
+	Types []TypeConfig `yaml:"types,omitempty"`
 	// Generators is a list of names that reference a generator in the Config struct.
 	Generators []string `yaml:"generators,omitempty"`
 }
@@ -59,6 +57,13 @@ type GeneratorConfig struct {
 	TemplateDir     string `yaml:"template_dir,omitempty"`
 	FileName        string `yaml:"fileName,omitempty"`
 	TemplateName    string `yaml:"templateName,omitempty"`
+}
+
+// TypeConfig is the information about which types to render and any data specific to handling of the type.
+type TypeConfig struct {
+	Name string `yaml:"name"`
+	// TypeOverride is the Golang type to override whatever the default detected type would be.
+	TypeOverride string `yaml:"type_override,omitempty"`
 }
 
 const (

--- a/internal/schema/schema_util.go
+++ b/internal/schema/schema_util.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 
 	log "github.com/sirupsen/logrus"
+
+	"github.com/newrelic/tutone/internal/config"
 )
 
 // filterDescription uses a regex to parse certain data out of the
@@ -48,8 +50,8 @@ func formatDescription(name string, description string) string {
 	return strings.Join(resultLines, "\n")
 }
 
-// typeNameInTypes determines if a name is already present in a set of TypeInfo.
-func typeNameInTypes(s string, types []TypeInfo) bool {
+// typeNameInTypes determines if a name is already present in a set of config.TypeConfig.
+func typeNameInTypes(s string, types []config.TypeConfig) bool {
 	for _, t := range types {
 		if t.Name == s {
 			return true
@@ -123,9 +125,9 @@ func ExpandType(s *Schema, t *Type) (*[]*Type, error) {
 	return &f, nil
 }
 
-// ExpandTypes receives a set of TypeInfo, which is then expanded to include
+// ExpandTypes receives a set of config.TypeConfig, which is then expanded to include
 // all the nested types from the fields.
-func ExpandTypes(s *Schema, types []TypeInfo) (*[]*Type, error) {
+func ExpandTypes(s *Schema, types []config.TypeConfig) (*[]*Type, error) {
 	if s == nil {
 		return nil, fmt.Errorf("unable to expand types from nil schema")
 	}


### PR DESCRIPTION
Without this change, the ability to override a type specification that was
available in PoC of this work is not respected here.  Here we implement this
capability to ensure we are able to handle special use cases as they come up.