### PR TITLE
fix(schema): use correct name for lookups

### DIFF
--- a/internal/schema/schema_util_test.go
+++ b/internal/schema/schema_util_test.go
@@ -60,6 +60,13 @@ func TestExpandTypes(t *testing.T) {
 			Methods:       []config.MethodConfig{},
 			ExpectedNames: []string{"CloudLinkedAccount", "EpochSeconds", "Int", "String", "CloudIntegration", "CloudProvider"},
 		},
+		"leveraging string replacer": {
+			Types: []config.TypeConfig{},
+			Methods: []config.MethodConfig{{
+				Name: "apiAccessCreateKeys",
+			}},
+			ExpectedNames: []string{"ApiAccessCreateIngestKeyInput", "ApiAccessCreateInput", "ApiAccessCreateKeyResponse", "ApiAccessCreateUserKeyInput", "ApiAccessIngestKeyType", "ApiAccessKey", "ApiAccessKeyError", "Int"},
+		},
 	}
 
 	for _, tc := range cases {

--- a/internal/schema/typeref.go
+++ b/internal/schema/typeref.go
@@ -87,7 +87,7 @@ func (r *TypeRef) GetType() (string, bool, error) {
 	case "":
 		return "", true, fmt.Errorf("empty field name: %+v", r)
 	default:
-		return n, true, nil
+		return formatGoName(n), true, nil
 	}
 }
 

--- a/pkg/lang/golang.go
+++ b/pkg/lang/golang.go
@@ -170,7 +170,7 @@ func GenerateGoTypesForPackage(s *schema.Schema, genConfig *config.GeneratorConf
 		switch t.Kind {
 		case schema.KindInputObject, schema.KindObject, schema.KindInterface:
 			xxx := GoStruct{
-				Name:        t.Name,
+				Name:        t.GetName(),
 				Description: t.GetDescription(),
 			}
 
@@ -245,13 +245,13 @@ func GenerateGoTypesForPackage(s *schema.Schema, genConfig *config.GeneratorConf
 			structsForGen = append(structsForGen, xxx)
 		case schema.KindENUM:
 			xxx := GoEnum{
-				Name:        t.Name,
+				Name:        t.GetName(),
 				Description: t.GetDescription(),
 			}
 
 			for _, v := range t.EnumValues {
 				value := GoEnumValue{
-					Name:        v.Name,
+					Name:        v.GetName(),
 					Description: v.GetDescription(),
 				}
 


### PR DESCRIPTION
Without this change, the modified name of the type is sometimes used when determining if a type should be included in the expanded set, which results in odd behavior, or some types failing to be matched because their name has been modified before the lookup call.

Here we ensure that the lookup of types is performed based on their name as represented in the schema, rather than what we want to impose upon the name based on the language we are working with.