### PR TITLE
Implement Possible Types

### DIFF
--- a/internal/schema/expander.go
+++ b/internal/schema/expander.go
@@ -1,0 +1,165 @@
+package schema
+
+import (
+	"fmt"
+	"sort"
+	"sync"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// Expander is mean to hold the state while the schema is being expanded.
+type Expander struct {
+	sync.Mutex
+	schema        *Schema
+	expandedTypes []*Type
+}
+
+// NewExpander is to return a sane Expander.
+func NewExpander(schema *Schema) *Expander {
+	return &Expander{
+		schema: schema,
+	}
+}
+
+// ExpandedTypes is the final report of all the expanded types.
+func (x *Expander) ExpandedTypes() *[]*Type {
+	x.Lock()
+	expandedTypes := x.expandedTypes
+	x.Unlock()
+
+	for _, expandedType := range expandedTypes {
+		log.WithFields(log.Fields{
+			"name": expandedType.Name,
+			"kind": expandedType.Kind,
+		}).Debug("type included")
+	}
+
+	sort.SliceStable(expandedTypes, func(i, j int) bool {
+		return expandedTypes[i].Name < expandedTypes[j].Name
+	})
+
+	return &expandedTypes
+}
+
+// ExpandType is used to populate the expander, one Type at a time.
+func (x *Expander) ExpandType(t *Type) (err error) {
+	if t == nil {
+		return fmt.Errorf("unable to expand nil Type")
+	}
+
+	if ok := x.includeType(t); ok {
+		err := x.expandType(t)
+		if err != nil {
+			log.WithFields(log.Fields{
+				"name": t.Name,
+			}).Errorf("failed to expand type: %s", err)
+
+		}
+	}
+
+	return nil
+}
+
+// ExpandTypeFromName will expand a named type if found or error.
+func (x *Expander) ExpandTypeFromName(name string) error {
+	t, err := x.schema.LookupTypeByName(name)
+	if err != nil {
+		return fmt.Errorf("failed lookup method argument: %s", err)
+	}
+
+	return x.ExpandType(t)
+}
+
+// includeType is used make sure a Type has been expanded.  A boolean ok is
+// returned if the type was included.  A false value means that the type was
+// already included.
+func (x *Expander) includeType(t *Type) bool {
+	var ok bool
+
+	x.Lock()
+	if !hasType(t, x.expandedTypes) {
+		log.WithFields(log.Fields{
+			"name": t.Name,
+		}).Trace("including type")
+
+		x.expandedTypes = append(x.expandedTypes, t)
+		ok = true
+	}
+	x.Unlock()
+
+	return ok
+}
+
+// expandType receives a Type which is used to determine the Type for all
+// nested fields.
+func (x *Expander) expandType(t *Type) error {
+	if t == nil {
+		return fmt.Errorf("unable to expand nil type")
+	}
+
+	// InputFields and Fields are handled the same way, so combine them to loop over.
+	var fields []Field
+	fields = append(fields, t.Fields...)
+	fields = append(fields, t.InputFields...)
+
+	log.WithFields(log.Fields{
+		"name":              t.GetName(),
+		"interfaces":        t.Interfaces,
+		"possibleTypes":     t.PossibleTypes,
+		"kind":              t.Kind,
+		"fields_count":      len(t.Fields),
+		"inputFields_count": len(t.InputFields),
+	}).Debugf("expanding type %s", t.Name)
+
+	// Collect the nested types from InputFields and Fields.
+	for _, i := range fields {
+		log.WithFields(log.Fields{
+			"name": i.GetName(),
+			"type": i.Type,
+			"args": i.Args,
+		}).Debugf("expanding field %s", i.Name)
+
+		var err error
+
+		if i.Type.OfType != nil {
+			err = x.ExpandTypeFromName(i.Type.OfType.GetTypeName())
+			if err != nil {
+				log.WithFields(log.Fields{
+					"ofType": i.Type.OfType.GetTypeName(),
+					"type":   i.Type.Name,
+				}).Errorf("failed to expand OfType for Type: %s", err)
+				// continue
+			}
+		}
+
+		if i.Type.Name != "" {
+			err = x.ExpandTypeFromName(i.Type.Name)
+			if err != nil {
+				log.WithFields(log.Fields{
+					"type": i.Type.Name,
+				}).Errorf("failed to expand Type.Name: %s", err)
+			}
+		}
+
+		for _, possibleType := range t.PossibleTypes {
+			err := x.ExpandTypeFromName(possibleType.Name)
+			if err != nil {
+				log.WithFields(log.Fields{
+					"name": possibleType.Name,
+				}).Errorf("failed to expand type from name: %s", err)
+			}
+		}
+
+		for _, typeInterface := range t.Interfaces {
+			err := x.ExpandTypeFromName(typeInterface.Name)
+			if err != nil {
+				log.WithFields(log.Fields{
+					"name": typeInterface.Name,
+				}).Errorf("failed to expand type from name: %s", err)
+			}
+		}
+	}
+
+	return nil
+}

--- a/internal/schema/schema_util.go
+++ b/internal/schema/schema_util.go
@@ -3,7 +3,6 @@ package schema
 import (
 	"fmt"
 	"regexp"
-	"sort"
 	"strings"
 
 	log "github.com/sirupsen/logrus"
@@ -73,6 +72,10 @@ func methodNameInMethods(s string, methods []config.MethodConfig) bool {
 
 // hasType determines if a Type is already present in a slice of Type objects.
 func hasType(t *Type, types []*Type) bool {
+	if t == nil {
+		log.Warn("hasType(nil)")
+	}
+
 	for _, tt := range types {
 		if t.Name == tt.Name {
 			return true
@@ -82,168 +85,6 @@ func hasType(t *Type, types []*Type) bool {
 	return false
 }
 
-// ExpandType receives a Type which is used to determine the Type for all
-// nested fields.
-func ExpandType(s *Schema, t *Type) (*[]*Type, error) {
-	if s == nil {
-		return nil, fmt.Errorf("unable to expand type from nil schema")
-	}
-
-	if t == nil {
-		return nil, fmt.Errorf("unable to expand nil type")
-	}
-
-	var expandedTypes []*Type
-
-	// InputFields and Fields are handled the same way, so combine them to loop over.
-	var fields []Field
-	fields = append(fields, t.Fields...)
-	fields = append(fields, t.InputFields...)
-
-	log.WithFields(log.Fields{
-		"name":              t.GetName(),
-		"interfaces":        t.Interfaces,
-		"possibleTypes":     t.PossibleTypes,
-		"kind":              t.Kind,
-		"fields_count":      len(t.Fields),
-		"inputFields_count": len(t.InputFields),
-	}).Debugf("expanding type %s", t.Name)
-
-	// Collect the nested types from InputFields and Fields.
-	for _, i := range fields {
-
-		log.WithFields(log.Fields{
-			"name": i.GetName(),
-			"type": i.Type,
-			"args": i.Args,
-		}).Debugf("expanding field %s", i.Name)
-
-		var result *Type
-		var err error
-
-		if i.Type.OfType != nil {
-			log.WithFields(log.Fields{
-				"ofType":     i.Type.OfType.GetName(),
-				"ofTypeName": i.Type.OfType.GetTypeName(),
-				"ofTypeKind": i.Type.OfType.GetKinds(),
-			}).Debug("field ofType")
-
-			result, err = s.LookupTypeByName(i.Type.OfType.GetTypeName())
-			if err != nil {
-				log.Error(err)
-				continue
-			}
-		} else if i.Type.Kind == KindObject || i.Type.Kind == KindInputObject || i.Type.Kind == KindENUM {
-			result, err = s.LookupTypeByName(i.Type.Name)
-			if err != nil {
-				log.WithFields(log.Fields{
-					// "name": i.Type.Name,
-					// "kind": i.Type.Kind,
-				}).Errorf("failed lookup type name: %s", err)
-				continue
-			}
-		} else {
-			log.WithFields(log.Fields{
-				"name": i.GetName(),
-				"type": i.Type,
-			}).Debugf("not expanding %s", i.Name)
-		}
-
-		if result != nil {
-			log.WithFields(log.Fields{
-				"name": result.Name,
-				"kind": result.Kind,
-			}).Debug("type found for field")
-
-			if !hasType(result, expandedTypes) {
-				expandedTypes = append(expandedTypes, result)
-			}
-
-			// Avoid recursing forever, since an interface has dependencies that will
-			// likely reference the interface.  For all other Kinds, we want to
-			// continue to expand.
-			if result.Kind != KindInterface {
-				processed, err := expandLookupResults(s, result)
-				if err != nil {
-					log.WithFields(log.Fields{
-						// "name": methodArg.Name,
-						// "type": methodArg.Type,
-					}).Errorf("failed to expand lookup result: %s", err)
-				}
-
-				if processed != nil {
-					for _, f := range *processed {
-						if !hasType(f, expandedTypes) {
-							expandedTypes = append(expandedTypes, f)
-						}
-					}
-				}
-			} else {
-				// KindInterface should also look for possibleTypes
-				for _, possibleType := range result.PossibleTypes {
-					r, err := s.LookupTypeByName(possibleType.Name)
-					if err != nil {
-						log.WithFields(log.Fields{
-							// "name": i.Type.Name,
-							// "kind": i.Type.Kind,
-						}).Errorf("failed lookup possibleType name: %s", err)
-						continue
-					}
-
-					processed, err := expandLookupResults(s, r)
-					if err != nil {
-						log.WithFields(log.Fields{
-							// "name": methodArg.Name,
-							// "type": methodArg.Type,
-						}).Errorf("failed to expand lookup result: %s", err)
-					}
-
-					if processed != nil {
-						for _, f := range *processed {
-							if !hasType(f, expandedTypes) {
-								expandedTypes = append(expandedTypes, f)
-							}
-						}
-					}
-
-				}
-			}
-
-		}
-
-	}
-
-	return &expandedTypes, nil
-}
-
-// expandTypesFromName is used to operate over the schema, and expand the results based on a type name received as a string.
-func expandTypesFromName(s *Schema, name string) (*[]*Type, error) {
-	var expandedTypes []*Type
-
-	result, err := s.LookupTypeByName(name)
-	if err != nil {
-		return nil, fmt.Errorf("failed lookup method argument: %s", err)
-	}
-
-	processed, err := expandLookupResults(s, result)
-	if err != nil {
-		log.WithFields(log.Fields{
-			// "name": methodArg.Name,
-			// "type": methodArg.Type,
-		}).Errorf("failed to process lookup result: %s", err)
-	}
-
-	if processed != nil {
-		for _, f := range *processed {
-			if !hasType(f, expandedTypes) {
-				expandedTypes = append(expandedTypes, f)
-			}
-		}
-	}
-
-	return &expandedTypes, nil
-}
-
 // ExpandTypes receives a set of config.TypeConfig, which is then expanded to include
 // all the nested types from the fields.
 func ExpandTypes(s *Schema, types []config.TypeConfig, methods []config.MethodConfig) (*[]*Type, error) {
@@ -251,30 +92,20 @@ func ExpandTypes(s *Schema, types []config.TypeConfig, methods []config.MethodCo
 		return nil, fmt.Errorf("unable to expand types from nil schema")
 	}
 
-	var expandedTypes []*Type
+	var err error
+	expander := NewExpander(s)
 
 	for _, schemaType := range s.Types {
 		if schemaType != nil {
-
 			// Constrain our handling to include only the type names which are mentioned in the configuration.
 			if typeNameInTypes(schemaType.Name, types) {
 				log.WithFields(log.Fields{
 					"name": schemaType.GetName(),
 				}).Debugf("config type: %s", schemaType.Name)
-				if !hasType(schemaType, expandedTypes) {
-					expandedTypes = append(expandedTypes, schemaType)
-				}
 
-				fieldTypes, err := ExpandType(s, schemaType)
+				err = expander.ExpandType(schemaType)
 				if err != nil {
 					log.Error(err)
-				}
-
-				// Avoid duplicates, append the unique names to the set
-				for _, f := range *fieldTypes {
-					if !hasType(f, expandedTypes) {
-						expandedTypes = append(expandedTypes, f)
-					}
 				}
 			}
 		}
@@ -285,117 +116,31 @@ func ExpandTypes(s *Schema, types []config.TypeConfig, methods []config.MethodCo
 	methodFields = append(methodFields, s.MutationType.InputFields...)
 
 	for _, field := range methodFields {
-
 		// Constrain our handling to include only the method names which are mentioned in the configuration.
 		if methodNameInMethods(field.Name, methods) {
-			log.WithFields(log.Fields{
-				"name": field.GetName(),
-			}).Debugf("config method: %s", field.Name)
-
-			results, err := expandTypesFromName(s, field.Type.Name)
+			err = expander.ExpandTypeFromName(field.Type.Name)
 			if err != nil {
 				log.WithFields(log.Fields{
-					// "name": methodArg.Name,
-					// "type": methodArg.Type,
-				}).Errorf("failed lookup method argument: %s", err)
-				continue
-			}
-
-			if results != nil {
-				for _, f := range *results {
-					if !hasType(f, expandedTypes) {
-						expandedTypes = append(expandedTypes, f)
-					}
-				}
+					"name":  field.Type.Name,
+					"field": field.Name,
+				}).Errorf("unable to expand method field type: %s", err)
 			}
 
 			for _, methodArg := range field.Args {
-				log.WithFields(log.Fields{
-					"method": field.Name,
-					"name":   methodArg.Name,
-				}).Debug("argument for method")
-
 				if methodArg.Type.OfType != nil {
-					results, err := expandTypesFromName(s, methodArg.Type.OfType.GetTypeName())
+					err := expander.ExpandTypeFromName(methodArg.Type.OfType.GetTypeName())
 					if err != nil {
 						log.WithFields(log.Fields{
 							"name": methodArg.Name,
 							"type": methodArg.Type,
-						}).Errorf("failed lookup method argument: %s", err)
-						continue
-					}
-
-					if results != nil {
-						for _, f := range *results {
-							if !hasType(f, expandedTypes) {
-								expandedTypes = append(expandedTypes, f)
-							}
-						}
+						}).Errorf("failed to expand method argument: %s", err)
 					}
 				}
-
-				results, err := expandTypesFromName(s, methodArg.Type.Name)
-				if err != nil {
-					log.WithFields(log.Fields{
-						"name": methodArg.Name,
-						"type": methodArg.Type,
-					}).Errorf("failed to process lookup result: %s", err)
-				}
-
-				if results != nil {
-					for _, f := range *results {
-						if !hasType(f, expandedTypes) {
-							expandedTypes = append(expandedTypes, f)
-						}
-					}
-				}
-
 			}
 		}
 	}
 
-	sort.SliceStable(expandedTypes, func(i, j int) bool {
-		return expandedTypes[i].Name < expandedTypes[j].Name
-	})
-
-	for _, expandedType := range expandedTypes {
-		log.WithFields(log.Fields{
-			"name": expandedType.Name,
-			"kind": expandedType.Kind,
-		}).Debug("type included")
-	}
-
-	return &expandedTypes, nil
-}
-
-// expandLookupResults is used to operate over a schema to expand the received type.
-func expandLookupResults(s *Schema, result *Type) (*[]*Type, error) {
-	if result == nil {
-		return nil, fmt.Errorf("unable to process nil result")
-	}
-
-	var expandedTypes []*Type
-
-	// Append the nested type to the result set.
-	if !hasType(result, expandedTypes) {
-		expandedTypes = append(expandedTypes, result)
-	}
-
-	// Recursively expand any fields of the nested type
-	subExpanded, err := ExpandType(s, result)
-	if err != nil {
-		return nil, fmt.Errorf("failed to expand type %s: %s", result.Name, err)
-	}
-
-	// Append the nested sub-types into the result set.
-	if subExpanded != nil {
-		for _, f := range *subExpanded {
-			if !hasType(f, expandedTypes) {
-				expandedTypes = append(expandedTypes, f)
-			}
-		}
-	}
-	return &expandedTypes, nil
+	return expander.ExpandedTypes(), nil
 }
 
 // formatGoName formats a name string using a few special cases for proper capitalization.

--- a/internal/schema/schema_util.go
+++ b/internal/schema/schema_util.go
@@ -178,6 +178,35 @@ func ExpandType(s *Schema, t *Type) (*[]*Type, error) {
 						}
 					}
 				}
+			} else {
+				// KindInterface should also look for possibleTypes
+				for _, possibleType := range result.PossibleTypes {
+					r, err := s.LookupTypeByName(possibleType.Name)
+					if err != nil {
+						log.WithFields(log.Fields{
+							// "name": i.Type.Name,
+							// "kind": i.Type.Kind,
+						}).Errorf("failed lookup possibleType name: %s", err)
+						continue
+					}
+
+					processed, err := expandLookupResults(s, r)
+					if err != nil {
+						log.WithFields(log.Fields{
+							// "name": methodArg.Name,
+							// "type": methodArg.Type,
+						}).Errorf("failed to expand lookup result: %s", err)
+					}
+
+					if processed != nil {
+						for _, f := range *processed {
+							if !hasType(f, expandedTypes) {
+								expandedTypes = append(expandedTypes, f)
+							}
+						}
+					}
+
+				}
 			}
 
 		}

--- a/internal/schema/schema_util.go
+++ b/internal/schema/schema_util.go
@@ -430,6 +430,11 @@ func formatGoName(name string) string {
 
 	r := strings.NewReplacer(
 		"Api", "API",
+		"Guid", "GUID",
+		"Nrql", "NRQL",
+		"Nrdb", "NRDB",
+		"Url", "URL",
+		"ApplicationId", "ApplicationID",
 	)
 
 	fieldName = r.Replace(fieldName)

--- a/internal/schema/schema_util_test.go
+++ b/internal/schema/schema_util_test.go
@@ -44,28 +44,28 @@ func TestExpandTypes(t *testing.T) {
 			Methods: []config.MethodConfig{{
 				Name: "alertsNrqlConditionBaselineCreate",
 			}},
-			ExpectedNames: []string{"AlertsFillOption", "AlertsNrqlBaselineCondition", "AlertsNrqlBaselineDirection", "AlertsNrqlConditionBaselineInput", "AlertsNrqlConditionExpiration", "AlertsNrqlConditionExpirationInput", "AlertsNrqlConditionPriority", "AlertsNrqlConditionQuery", "AlertsNrqlConditionQueryInput", "AlertsNrqlConditionSignal", "AlertsNrqlConditionSignalInput", "AlertsNrqlConditionTerms", "AlertsNrqlConditionTermsOperator", "AlertsNrqlConditionThresholdOccurrences", "AlertsNrqlConditionType", "AlertsNrqlDynamicConditionTermsInput", "AlertsNrqlDynamicConditionTermsOperator", "AlertsViolationTimeLimit", "Boolean", "Float", "ID", "Int", "String"},
+			ExpectedNames: []string{"AlertsFillOption", "AlertsNrqlBaselineCondition", "AlertsNrqlBaselineDirection", "AlertsNrqlCondition", "AlertsNrqlConditionBaselineInput", "AlertsNrqlConditionExpiration", "AlertsNrqlConditionExpirationInput", "AlertsNrqlConditionPriority", "AlertsNrqlConditionQuery", "AlertsNrqlConditionQueryInput", "AlertsNrqlConditionSignal", "AlertsNrqlConditionSignalInput", "AlertsNrqlConditionTerms", "AlertsNrqlConditionTermsOperator", "AlertsNrqlConditionThresholdOccurrences", "AlertsNrqlConditionType", "AlertsNrqlDynamicConditionTermsInput", "AlertsNrqlDynamicConditionTermsOperator", "AlertsNrqlOutlierCondition", "AlertsNrqlStaticCondition", "AlertsNrqlStaticConditionValueFunction", "AlertsViolationTimeLimit", "Boolean", "Float", "ID", "Int", "Seconds", "String"},
 		},
 		"sample interface type": {
 			Types: []config.TypeConfig{{
 				Name: "CloudProvider",
 			}},
 			Methods:       []config.MethodConfig{},
-			ExpectedNames: []string{"Boolean", "CloudProvider", "CloudService", "EpochSeconds", "Int", "String"},
+			ExpectedNames: []string{"Boolean", "CloudAwsGovCloudProvider", "CloudAwsProvider", "CloudBaseProvider", "CloudGcpProvider", "CloudProvider", "CloudService", "EpochSeconds", "Int", "String"},
 		},
 		"nested slice of interface": {
 			Types: []config.TypeConfig{{
 				Name: "CloudLinkedAccount",
 			}},
 			Methods:       []config.MethodConfig{},
-			ExpectedNames: []string{"CloudLinkedAccount", "EpochSeconds", "Int", "String", "CloudIntegration", "CloudProvider"},
+			ExpectedNames: []string{"Boolean", "CloudAlbIntegration", "CloudApigatewayIntegration", "CloudAutoscalingIntegration", "CloudAwsAppsyncIntegration", "CloudAwsAthenaIntegration", "CloudAwsDirectconnectIntegration", "CloudAwsDocdbIntegration", "CloudAwsGlueIntegration", "CloudAwsGovCloudProvider", "CloudAwsMqIntegration", "CloudAwsMskIntegration", "CloudAwsProvider", "CloudAwsQldbIntegration", "CloudAwsStatesIntegration", "CloudAwsWafIntegration", "CloudAzureApimanagementIntegration", "CloudAzureAppserviceIntegration", "CloudAzureCosmosdbIntegration", "CloudAzureCostmanagementIntegration", "CloudAzureFunctionsIntegration", "CloudAzureLoadbalancerIntegration", "CloudAzureMariadbIntegration", "CloudAzureMysqlIntegration", "CloudAzurePostgresqlIntegration", "CloudAzureRediscacheIntegration", "CloudAzureServicebusIntegration", "CloudAzureSqlIntegration", "CloudAzureSqlmanagedIntegration", "CloudAzureStorageIntegration", "CloudAzureVirtualmachineIntegration", "CloudAzureVirtualnetworksIntegration", "CloudAzureVmsIntegration", "CloudBaseIntegration", "CloudBaseProvider", "CloudBillingIntegration", "CloudCloudfrontIntegration", "CloudCloudtrailIntegration", "CloudDynamodbIntegration", "CloudEbsIntegration", "CloudEc2Integration", "CloudEcsIntegration", "CloudEfsIntegration", "CloudElasticacheIntegration", "CloudElasticbeanstalkIntegration", "CloudElasticsearchIntegration", "CloudElbIntegration", "CloudEmrIntegration", "CloudGcpAppengineIntegration", "CloudGcpBigqueryIntegration", "CloudGcpFunctionsIntegration", "CloudGcpKubernetesIntegration", "CloudGcpLoadbalancingIntegration", "CloudGcpProvider", "CloudGcpPubsubIntegration", "CloudGcpSpannerIntegration", "CloudGcpSqlIntegration", "CloudGcpStorageIntegration", "CloudGcpVmsIntegration", "CloudHealthIntegration", "CloudIamIntegration", "CloudIntegration", "CloudIotIntegration", "CloudKinesisFirehoseIntegration", "CloudKinesisIntegration", "CloudLambdaIntegration", "CloudLinkedAccount", "CloudProvider", "CloudRdsIntegration", "CloudRedshiftIntegration", "CloudRoute53Integration", "CloudS3Integration", "CloudService", "CloudSesIntegration", "CloudSnsIntegration", "CloudSqsIntegration", "CloudTrustedadvisorIntegration", "CloudVpcIntegration", "EpochSeconds", "Int", "String"},
 		},
 		"leveraging string replacer": {
 			Types: []config.TypeConfig{},
 			Methods: []config.MethodConfig{{
 				Name: "apiAccessCreateKeys",
 			}},
-			ExpectedNames: []string{"ApiAccessCreateIngestKeyInput", "ApiAccessCreateInput", "ApiAccessCreateKeyResponse", "ApiAccessCreateUserKeyInput", "ApiAccessIngestKeyType", "ApiAccessKey", "ApiAccessKeyError", "Int"},
+			ExpectedNames: []string{"ApiAccessCreateKeyResponse", "ApiAccessIngestKey", "ApiAccessIngestKeyError", "ApiAccessIngestKeyErrorType", "ApiAccessIngestKeyType", "ApiAccessKey", "ApiAccessKeyError", "ApiAccessKeyType", "ApiAccessUserKey", "ApiAccessUserKeyError", "ApiAccessUserKeyErrorType", "ID", "Int", "String"},
 		},
 	}
 

--- a/pkg/lang/golang.go
+++ b/pkg/lang/golang.go
@@ -149,6 +149,9 @@ func GenerateGoMethodsForPackage(s *schema.Schema, genConfig *config.GeneratorCo
 	}
 
 	if len(methods) > 0 {
+		sort.SliceStable(methods, func(i, j int) bool {
+			return methods[i].Name < methods[j].Name
+		})
 		return &methods, nil
 	}
 


### PR DESCRIPTION
Here we ensure that the interface type is now consulted for its "possibleTypes" to ensure we gather the implementations.  This works now because we have a circuit breaker to avoid the forever-recurse when handling interface types.