### PR TITLE
Handle query method input variables

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -926,6 +926,7 @@ golang.org/x/net v0.0.0-20200625001655-4c5254603344 h1:vGXIOMxbNfDTk/aXCmfdLgkrS
 golang.org/x/net v0.0.0-20200625001655-4c5254603344/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20200707034311-ab3426394381 h1:VXak5I6aEWmAXeQjA+QSZzlgNrpq9mjcfDemuexIKsU=
 golang.org/x/net v0.0.0-20200707034311-ab3426394381/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
+golang.org/x/net v0.0.0-20200822124328-c89045814202 h1:VvcQYSHwXgi7W+TpUR6A9g6Up98WAHf3f/ulnJ62IyA=
 golang.org/x/net v0.0.0-20200822124328-c89045814202/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20181106182150-f42d05182288/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=

--- a/internal/schema/schema.go
+++ b/internal/schema/schema.go
@@ -170,6 +170,36 @@ func (s *Schema) LookupQueryTypesByFieldPath(fieldPath []string) ([]*Type, error
 	return types, nil
 }
 
+// GetInputFieldsForQueryPath is intended to return the fields that are
+// available as input arguments when performing a query using the received
+// query path.  For example, a []string{"actor", "account"} would look at the
+// representivate types at those schema levels and determine collect the
+// available arguments for return.
+func (s *Schema) GetInputFieldsForQueryPath(queryPath []string) map[string][]Field {
+	fields := make(map[string][]Field)
+
+	pathTypes, err := s.LookupQueryTypesByFieldPath(queryPath)
+	if err != nil {
+		log.Error(err)
+	}
+
+	for i, t := range pathTypes {
+		for _, f := range t.Fields {
+			// before the last element
+			if i+1 < len(queryPath) {
+				pathName := queryPath[i+1]
+				if f.Name == pathName {
+					if len(f.Args) > 0 {
+						fields[pathName] = append(fields[pathName], f.Args...)
+					}
+				}
+			}
+		}
+	}
+
+	return fields
+}
+
 // QueryFieldsForTypeName will lookup a type by the received name, and return
 // the query fields for that type, or log an error and return and empty string.
 // The returned string is used in a mutation, so that the relevant fields are

--- a/internal/schema/schema_test.go
+++ b/internal/schema/schema_test.go
@@ -171,6 +171,11 @@ func TestSchema_GetQueryStringForEndpoint(t *testing.T) {
 			Field: "linkedAccounts",
 			Depth: 2,
 		},
+		"policy": {
+			Path:  []string{"actor", "account", "alerts"},
+			Field: "policy",
+			Depth: 2,
+		},
 	}
 
 	for n, tc := range cases {

--- a/internal/schema/schema_test.go
+++ b/internal/schema/schema_test.go
@@ -48,6 +48,14 @@ func TestSchema_QueryArgs(t *testing.T) {
 		Fields  []string
 		Results []QueryArg
 	}{
+		"accountEntities": {
+			Name:   "Actor",
+			Fields: []string{"account", "entities"},
+			Results: []QueryArg{
+				{Key: "id", Value: "Int!"},
+				{Key: "guids", Value: "[EntityGuid]!"},
+			},
+		},
 		"entities": {
 			Name:   "Actor",
 			Fields: []string{"entities"},
@@ -203,5 +211,48 @@ func TestSchema_GetQueryStringForMutation(t *testing.T) {
 		// saveFixture(t, n, result)
 		expected := loadFixture(t, n)
 		assert.Equal(t, expected, result)
+	}
+}
+
+func TestSchema_GetInputFieldsForQueryPath(t *testing.T) {
+	t.Parallel()
+
+	// schema cached by 'make test-prep'
+	s, err := Load("../../testdata/schema.json")
+	require.NoError(t, err)
+
+	cases := map[string]struct {
+		QueryPath []string
+		Fields    map[string][]string
+	}{
+		"accountCloud": {
+			QueryPath: []string{"actor", "account", "cloud"},
+			Fields: map[string][]string{
+				"account": {"id"},
+			},
+		},
+		"entities": {
+			QueryPath: []string{"actor", "entities"},
+			Fields: map[string][]string{
+				"entities": {"guids"},
+			},
+		},
+		"apiAccessKey": {
+			QueryPath: []string{"actor", "apiAccess", "key"},
+			Fields: map[string][]string{
+				"key": {"id", "keyType"},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		result := s.GetInputFieldsForQueryPath(tc.QueryPath)
+		assert.Equal(t, len(tc.Fields), len(result))
+		for pathName, fields := range tc.Fields {
+
+			for i, name := range fields {
+				assert.Equal(t, name, result[pathName][i].Name)
+			}
+		}
 	}
 }

--- a/internal/schema/testdata/TestSchema_GetQueryStringForEndpoint_entities.txt
+++ b/internal/schema/testdata/TestSchema_GetQueryStringForEndpoint_entities.txt
@@ -1,0 +1,7 @@
+query(
+	$guids: [EntityGuid]!,
+) { actor { entities(
+	guids: $guids,
+) {
+
+} } }

--- a/internal/schema/testdata/TestSchema_GetQueryStringForEndpoint_entitySearch.txt
+++ b/internal/schema/testdata/TestSchema_GetQueryStringForEndpoint_entitySearch.txt
@@ -1,11 +1,5 @@
 query(
-	$query: String,
-	$queryBuilder: EntitySearchQueryBuilder,
-	$sortBy: [EntitySearchSortCriteria],
 ) { actor { entitySearch(
-	query: $query,
-	queryBuilder: $queryBuilder,
-	sortBy: $sortBy,
 ) {
 	count
 	counts {
@@ -52,6 +46,7 @@ query(
 			}
 			... on BrowserApplicationEntityOutline {
 				__typename
+				agentInstallType
 				alertSeverity
 				applicationId
 				servingApmApplicationId

--- a/internal/schema/testdata/TestSchema_GetQueryStringForEndpoint_linkedAccounts.txt
+++ b/internal/schema/testdata/TestSchema_GetQueryStringForEndpoint_linkedAccounts.txt
@@ -1,7 +1,5 @@
 query(
-	$provider: String,
 ) { actor { cloud { linkedAccounts(
-	provider: $provider,
 ) {
 	authLabel
 	createdAt

--- a/internal/schema/testdata/TestSchema_GetQueryStringForEndpoint_policy.txt
+++ b/internal/schema/testdata/TestSchema_GetQueryStringForEndpoint_policy.txt
@@ -1,0 +1,11 @@
+query(
+	$accountID: Int!,
+	$id: ID!,
+) { actor { account(id: $accountID) { alerts { policy(
+	id: $id,
+) {
+	accountId
+	id
+	incidentPreference
+	name
+} } } } }

--- a/pkg/lang/golang.go
+++ b/pkg/lang/golang.go
@@ -529,7 +529,7 @@ func constrainedResponseStructs(s *schema.Schema, pkgConfig *config.PackageConfi
 //
 // The received inputFields are to seed the initial objet.  This allows the
 // caller to pass additional context about the received field's place in the
-// schema that are used as a starting place for input vairables, since the
+// schema that are used as a starting place for input variables, since the
 // parent objects may require those inputs.
 func goMethodForField(field schema.Field, pkgConfig *config.PackageConfig, inputFields map[string][]schema.Field) GoMethod {
 

--- a/pkg/lang/golang.go
+++ b/pkg/lang/golang.go
@@ -148,6 +148,8 @@ func GenerateGoMethodQueriesForPackage(s *schema.Schema, genConfig *config.Gener
 			returnPath = append(returnPath, strings.Title(t))
 		}
 
+		inputFields := s.GetInputFieldsForQueryPath(pkgQuery.Path)
+
 		// The endpoint we care about will always be on the last of the path elements specified.
 		t := typePath[len(typePath)-1]
 
@@ -159,7 +161,7 @@ func GenerateGoMethodQueriesForPackage(s *schema.Schema, genConfig *config.Gener
 			for _, field := range t.Fields {
 				if field.Name == endpoint.Name {
 
-					method := goMethodForField(s, field, pkgConfig)
+					method := goMethodForField(field, pkgConfig, inputFields)
 
 					method.QueryString = s.GetQueryStringForEndpoint(typePath, pkgQuery.Path, endpoint.Name, endpoint.MaxQueryFieldDepth)
 					method.ResponseObjectType = fmt.Sprintf("%sResponse", endpoint.Name)
@@ -202,15 +204,11 @@ func GenerateGoMethodMutationsForPackage(s *schema.Schema, genConfig *config.Gen
 			continue
 		}
 
-		// if field.Name == pkgMutation.Name {
-		method := goMethodForField(s, *field, pkgConfig)
-		// method.QueryString = schema.PrefixLineTab(s.QueryFieldsForTypeName(field.Type.GetTypeName(), pkgMutation.MaxQueryFieldDepth))
+		method := goMethodForField(*field, pkgConfig, nil)
 		method.QueryString = s.GetQueryStringForMutation(field, pkgMutation.MaxQueryFieldDepth)
 
 		methods = append(methods, method)
-		// }
 	}
-	// }
 
 	if len(methods) > 0 {
 		sort.SliceStable(methods, func(i, j int) bool {
@@ -506,7 +504,8 @@ func constrainedResponseStructs(s *schema.Schema, pkgConfig *config.PackageConfi
 				Name: fmt.Sprintf("%sResponse", endpoint.Name),
 			}
 
-			// For the top level response object, we only use the first field path that is received from the user.
+			// For the top level response object, we only use the first field path
+			// that is received from the user.
 			firstType := pathTypes[0]
 
 			field := GoStructField{
@@ -527,11 +526,46 @@ func constrainedResponseStructs(s *schema.Schema, pkgConfig *config.PackageConfi
 // goMethodForField creates a new GoMethod based on a field.  Note that the
 // implementation specific information like QueryString are not added to the
 // method, and it is up to the caller to flavor the method accordingly.
-func goMethodForField(s *schema.Schema, field schema.Field, pkgConfig *config.PackageConfig) GoMethod {
+//
+// The received inputFields are to seed the initial objet.  This allows the
+// caller to pass additional context about the received field's place in the
+// schema that are used as a starting place for input vairables, since the
+// parent objects may require those inputs.
+func goMethodForField(field schema.Field, pkgConfig *config.PackageConfig, inputFields map[string][]schema.Field) GoMethod {
 
 	method := GoMethod{
 		Name:        field.GetName(),
 		Description: field.GetDescription(),
+	}
+
+	for pathName, fields := range inputFields {
+		for _, f := range fields {
+			kinds := f.Type.GetKinds()
+			if kinds[0] == schema.KindNonNull {
+				typeName, err := f.GetTypeNameWithOverride(pkgConfig)
+				if err != nil {
+					log.Error(err)
+					continue
+				}
+
+				inputType := GoMethodInputType{
+					// Flavor the name of the input object with the field from the path
+					// in which we were found.
+					Name: fmt.Sprintf("%s%s", pathName, f.GetName()),
+					Type: typeName,
+				}
+
+				method.Signature.Input = append(method.Signature.Input, inputType)
+
+				queryVar := QueryVar{
+					Key:   inputType.Name,
+					Value: inputType.Name,
+					Type:  f.Type.GetTypeName(),
+				}
+
+				method.QueryVars = append(method.QueryVars, queryVar)
+			}
+		}
 	}
 
 	var prefix string
@@ -556,6 +590,8 @@ func goMethodForField(s *schema.Schema, field schema.Field, pkgConfig *config.Pa
 			Type: typeName,
 		}
 
+		method.Signature.Input = append(method.Signature.Input, inputType)
+
 		queryVar := QueryVar{
 			Key:   methodArg.Name,
 			Value: inputType.Name,
@@ -564,7 +600,6 @@ func goMethodForField(s *schema.Schema, field schema.Field, pkgConfig *config.Pa
 
 		method.QueryVars = append(method.QueryVars, queryVar)
 
-		method.Signature.Input = append(method.Signature.Input, inputType)
 	}
 
 	return method

--- a/pkg/lang/golang.go
+++ b/pkg/lang/golang.go
@@ -548,11 +548,16 @@ func goMethodForField(field schema.Field, pkgConfig *config.PackageConfig, input
 					continue
 				}
 
+				var prefix string
+				if kinds[1] == schema.KindList {
+					prefix = "[]"
+				}
+
 				inputType := GoMethodInputType{
 					// Flavor the name of the input object with the field from the path
 					// in which we were found.
 					Name: fmt.Sprintf("%s%s", pathName, f.GetName()),
-					Type: typeName,
+					Type: fmt.Sprintf("%s%s", prefix, typeName),
 				}
 
 				method.Signature.Input = append(method.Signature.Input, inputType)
@@ -585,9 +590,16 @@ func goMethodForField(field schema.Field, pkgConfig *config.PackageConfig, input
 			continue
 		}
 
+		methodArgKinds := methodArg.Type.GetKinds()
+
+		var methodArgPrefix string
+		if methodArgKinds[0] == schema.KindList {
+			methodArgPrefix = "[]"
+		}
+
 		inputType := GoMethodInputType{
 			Name: methodArg.GetName(),
-			Type: typeName,
+			Type: fmt.Sprintf("%s%s", methodArgPrefix, typeName),
 		}
 
 		method.Signature.Input = append(method.Signature.Input, inputType)


### PR DESCRIPTION
This work is to address an issue where a parent object may require arguments, but the query string doesn't contain the proper variables to send them with the request.  Here we implement what is required to ensure that any required argument of an endpoint is available, and also that the golang code here handles those arguments properly.