### PR TITLE
Allow custom methods to be added to an interface definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,20 @@ types and mutations to include from the schema, and where the package is located
 | mutations  | No       | A list of mutations from which to infer types                           |
 | types      | No       | A list of types from which to start expanding the inferred set of types |
 
+
+#### Type Configuration
+
+To fine-tune the types that are created, or not create them at all, the
+following options are supported:
+
+| Name                  | Required | Description |
+| --------------------- | -------- | ----------- |
+| `name`                | yes      | Name of the type to match |
+| `create_as`           | no       | Used when creating a new scalar type to determine which Go type to use. |
+| `field_type_override` | no       | Golang type to override whatever the default detected type would be for a given field. |
+| `interface_methods`   | no       | List of additional methods that are added to an interface definition. The methods are not defined in the code, so must be implemented by the user. |
+| `skip_type_create`    | no       | Allows the user to skip creating a type. |
+
 ### Generators
 
 The `generators` field is used to describe a given generator.  The generator is

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -128,6 +128,9 @@ type TypeConfig struct {
 	CreateAs string `yaml:"create_as,omitempty"`
 	// SkipTypeCreate allows the user to skip creating a Scalar type.
 	SkipTypeCreate bool `yaml:"skip_type_create,omitempty"`
+	// InterfaceMethods is a list of additional methods that are added to an interface definition. The methods are not
+	// defined in the code, so must be implemented by the user.
+	InterfaceMethods []string `yaml:"interface_methods,omitempty"`
 }
 
 const (

--- a/pkg/lang/golang.go
+++ b/pkg/lang/golang.go
@@ -353,7 +353,7 @@ func GenerateGoTypesForPackage(s *schema.Schema, genConfig *config.GeneratorConf
 				}
 
 				// Require at least one auto-generated method, allow others
-				yyy.Methods = make([]string, 2)
+				yyy.Methods = make([]string, len(interfaceMethods)+1)
 				yyy.Methods = append(yyy.Methods, "Implements"+t.GetName()+"()")
 				yyy.Methods = append(yyy.Methods, interfaceMethods...)
 

--- a/templates/clientgo/types.go.tmpl
+++ b/templates/clientgo/types.go.tmpl
@@ -7,13 +7,13 @@ type {{.Name}} string
 
 var {{.Name}}Types = struct {
   {{- range .Values}}
-	{{ .Description }}
-	{{.Name}} {{$typeName}}
+  {{ .Description }}
+  {{.Name}} {{$typeName}}
   {{- end}}
 }{
   {{- range .Values}}
-	{{ .Description }}
-	{{.Name}}: "{{.Name}}",
+  {{ .Description }}
+  {{.Name}}: "{{.Name}}",
   {{- end}}
 }
 {{ end}}

--- a/templates/typegen/types.go.tmpl
+++ b/templates/typegen/types.go.tmpl
@@ -16,13 +16,17 @@ type {{ .Name }} string
 
 var {{.Name}}Types = struct {
   {{- range .Values }}
-	{{ .Description }}
-	{{ .Name }} {{ $typeName }}
+  {{-   if ne .Description "" }}
+  {{      .Description }}
+  {{-   end }}
+  {{   .Name }} {{ $typeName }}
   {{- end}}
 }{
   {{- range .Values }}
-	{{ .Description }}
-	{{ .Name }}: "{{ .Name }}",
+  {{-   if ne .Description "" }}
+  {{      .Description }}
+  {{-   end }}
+  {{ .Name }}: "{{ .Name }}",
   {{- end}}
 }
 {{- end}}
@@ -32,8 +36,10 @@ var {{.Name}}Types = struct {
 {{- $typeName := .Name }}
 type {{.Name}} struct {
   {{- range .Fields }}
-  {{ .Description }}
-  {{ .Name }} {{ .Type }} {{ .Tags }}
+  {{-   if ne .Description "" }}
+  {{      .Description }}
+  {{-   end }}
+  {{    .Name }} {{ .Type }} {{ .Tags }}
   {{- end}}
 }
 
@@ -44,17 +50,17 @@ func (x *{{ $typeName }}) Implements{{ . }}() {}
 {{-  if .SpecialUnmarshal }}
 // special
 func (x *{{ $typeName }}) UnmarshalJSON(b []byte) error {
-	var objMap map[string]*json.RawMessage
-	err := json.Unmarshal(b, &objMap)
-	if err != nil {
-		return err
-	}
+  var objMap map[string]*json.RawMessage
+  err := json.Unmarshal(b, &objMap)
+  if err != nil {
+    return err
+  }
 
-	for k, v := range objMap {
-		switch k {
+  for k, v := range objMap {
+    switch k {
   {{- range .Fields }}
     {{- $field := . }}
-		case "{{ .TagKey }}":
+    case "{{ .TagKey }}":
     {{- if .IsInterface }}
       {{- if .IsList }}
         var rawMessage{{ .Name }} []*json.RawMessage
@@ -86,14 +92,14 @@ func (x *{{ $typeName }}) UnmarshalJSON(b []byte) error {
         }
       {{- end }}
     {{- else }}
-			err = json.Unmarshal(*v, &x.{{ .Name }})
-			if err != nil {
-				return err
-			}
+      err = json.Unmarshal(*v, &x.{{ .Name }})
+      if err != nil {
+        return err
+      }
     {{- end }}
   {{- end }}
-		}
-	}
+    }
+  }
 
   return nil
 }
@@ -101,15 +107,21 @@ func (x *{{ $typeName }}) UnmarshalJSON(b []byte) error {
 {{ end}}
 
 {{- range .Scalars }}
-{{ .Description }}
+{{-   if ne .Description "" }}
+{{      .Description }}
+{{-   end }}
 type {{.Name}} {{.Type}}
 {{- end}}
 
 {{- range .Interfaces }}
 {{- $interfaceType := . }}
-{{ .Description }}
+{{-   if ne .Description "" }}
+{{      .Description }}
+{{-   end }}
 type {{ $interfaceType.Name }}Interface interface{
-  Implements{{.Name}}()
+  {{- range $m := .Methods }}
+  {{ $m }}
+  {{- end }}
 }
 
 //yes

--- a/templates/typegen/types.go.tmpl
+++ b/templates/typegen/types.go.tmpl
@@ -63,6 +63,9 @@ func (x *{{ $typeName }}) UnmarshalJSON(b []byte) error {
     case "{{ .TagKey }}":
     {{- if .IsInterface }}
       {{- if .IsList }}
+        if v == nil {
+          continue
+        }
         var rawMessage{{ .Name }} []*json.RawMessage
         err = json.Unmarshal(*v, &rawMessage{{ .Name }})
         if err != nil {


### PR DESCRIPTION
We dynamically generate Interface implementations, but have no way to know what custom methods one might want on all of those interfaces. This allows you to configure additional methods that will be required to satisfy the interface.  Actual implementation is left as an exercise for the configurator.
