### PR TITLE
NerdGraphClient Refactors

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,14 @@ The generator configuration specifies details about how the generator should adj
 | name     | Yes      | The name of the generator used in `pkg/generate/generate.go` file            |
 | fileName | No       | Where to write the output of the generated code within the specified package |
 
+## Templates
+
+Example templates are available in the [templates/<generator>](templates/) directory, and are dynamically loaded from your project.
+
+* Rendered using [text/template](https://golang.org/pkg/text/template/)
+* Additional pipeline functions from [sprig](http://masterminds.github.io/sprig/)
+
+
 ## Community
 
 New Relic hosts and moderates an online forum where customers can interact with New Relic employees as well as other customers to get help and share best practices. 

--- a/configs/tutone.yml
+++ b/configs/tutone.yml
@@ -55,7 +55,13 @@ packages:
       - name: cloudConfigureIntegration
       - name: cloudDisableIntegration
       - name: cloudLinkAccount
+        argument_type_overrides:
+          accountId: "Int!"
+          accounts: "CloudLinkCloudAccountsInput!"
       - name: cloudRenameAccount
+        argument_type_overrides:
+          accountId: "Int!"
+          accounts: "[CloudRenameAccountsInput!]!"
       - name: cloudUnlinkAccount
 
 generators:

--- a/configs/tutone.yml
+++ b/configs/tutone.yml
@@ -49,7 +49,7 @@ packages:
       - path: ["actor", "cloud"]
         endpoints:
           - name: linkedAccounts
-            maxQueryFieldDepth: 2
+            max_query_field_depth: 2
             include_nullable: true
     mutations:
       - name: cloudConfigureIntegration

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/tj/assert v0.0.3
 	github.com/tsuyoshiwada/go-gitcmd v0.0.0-20180205145712-5f1f5f9475df // indirect
 	github.com/urfave/cli v1.22.5 // indirect
-	golang.org/x/tools v0.0.0-20201202100533-7534955ac86b
+	golang.org/x/tools v0.0.0-20201211185031-d93e913c1a58
 	gopkg.in/AlecAivazis/survey.v1 v1.8.7 // indirect
 	gopkg.in/kyokomi/emoji.v1 v1.5.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -1089,8 +1089,8 @@ golang.org/x/tools v0.0.0-20201007032633-0806396f153e/go.mod h1:z6u4i615ZeAfBE4X
 golang.org/x/tools v0.0.0-20201011145850-ed2f50202694/go.mod h1:z6u4i615ZeAfBE4XtMziQW1fSVJXACjjbWkB/mvPzlU=
 golang.org/x/tools v0.0.0-20201013201025-64a9e34f3752 h1:2ntEwh02rqo2jSsrYmp4yKHHjh0CbXP3ZtSUetSB+q8=
 golang.org/x/tools v0.0.0-20201013201025-64a9e34f3752/go.mod h1:z6u4i615ZeAfBE4XtMziQW1fSVJXACjjbWkB/mvPzlU=
-golang.org/x/tools v0.0.0-20201202100533-7534955ac86b h1:nOM4+lFhnC6uxSrRnxjZ4Azu1bF9DQz5rAsb3LUErhc=
-golang.org/x/tools v0.0.0-20201202100533-7534955ac86b/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
+golang.org/x/tools v0.0.0-20201211185031-d93e913c1a58 h1:1Bs6RVeBFtLZ8Yi1Hk07DiOqzvwLD/4hln4iahvFlag=
+golang.org/x/tools v0.0.0-20201211185031-d93e913c1a58/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7 h1:9zdDQZ7Thm29KFXgAX/+yaf3eVbP7djjWp/dXAppNCc=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898 h1:/atklqdjdhuosWIl6AIbOeHJjicWYPqR9bpxqxYG2pA=

--- a/internal/codegen/codegen.go
+++ b/internal/codegen/codegen.go
@@ -8,9 +8,10 @@ import (
 	"text/template"
 
 	"github.com/Masterminds/sprig/v3"
-	"github.com/newrelic/tutone/internal/output"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/tools/imports"
+
+	"github.com/newrelic/tutone/internal/output"
 )
 
 type CodeGen struct {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -112,9 +112,9 @@ type GeneratorConfig struct {
 // MutationConfig is the information about the GraphQL mutations.
 type MutationConfig struct {
 	// Name is the name of the GraphQL method.
-	Name               string   `yaml:"name"`
-	MaxQueryFieldDepth int      `yaml:"max_query_field_depth,omitempty"`
-	RequireFields      []string `yaml:"require_fields,omitempty"`
+	Name                  string            `yaml:"name"`
+	MaxQueryFieldDepth    int               `yaml:"max_query_field_depth,omitempty"`
+	ArgumentTypeOverrides map[string]string `yaml:"argument_type_overrides,omitempty"`
 }
 
 type EndpointConfig struct {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -113,7 +113,7 @@ type GeneratorConfig struct {
 type MutationConfig struct {
 	// Name is the name of the GraphQL method.
 	Name               string `yaml:"name"`
-	MaxQueryFieldDepth int    `yaml:"maxQueryFieldDepth,omitempty"`
+	MaxQueryFieldDepth int    `yaml:"max_query_field_depth,omitempty"`
 }
 
 type EndpointConfig struct {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -112,8 +112,9 @@ type GeneratorConfig struct {
 // MutationConfig is the information about the GraphQL mutations.
 type MutationConfig struct {
 	// Name is the name of the GraphQL method.
-	Name               string `yaml:"name"`
-	MaxQueryFieldDepth int    `yaml:"max_query_field_depth,omitempty"`
+	Name               string   `yaml:"name"`
+	MaxQueryFieldDepth int      `yaml:"max_query_field_depth,omitempty"`
+	RequireFields      []string `yaml:"require_fields,omitempty"`
 }
 
 type EndpointConfig struct {

--- a/internal/schema/field.go
+++ b/internal/schema/field.go
@@ -114,3 +114,13 @@ func (f *Field) IsEnum() bool {
 
 	return f.Type.OfType != nil && f.Type.OfType.Kind == KindENUM
 }
+
+func (f *Field) HasRequiredArg() bool {
+	for _, a := range f.Args {
+		if a.IsRequired() {
+			return true
+		}
+	}
+
+	return false
+}

--- a/internal/schema/field.go
+++ b/internal/schema/field.go
@@ -43,7 +43,7 @@ func (f *Field) GetTypeNameWithOverride(pkgConfig *config.PackageConfig) (string
 				log.WithFields(log.Fields{
 					"name":                nameToMatch,
 					"field_type_override": p.FieldTypeOverride,
-				}).Debug("overriding typeref")
+				}).Trace("overriding typeref")
 				overrideType = p.FieldTypeOverride
 			}
 		}

--- a/internal/schema/field.go
+++ b/internal/schema/field.go
@@ -75,7 +75,7 @@ func (f *Field) GetTags() string {
 
 	jsonTag := "`json:\"" + f.Name
 
-	if f.Type.IsInputObject() {
+	if f.Type.IsInputObject() || !f.Type.IsNonNull() {
 		jsonTag += ",omitempty"
 	}
 

--- a/internal/schema/field.go
+++ b/internal/schema/field.go
@@ -75,6 +75,10 @@ func (f *Field) GetTags() string {
 
 	jsonTag := "`json:\"" + f.Name
 
+	if f.Type.IsInputObject() {
+		jsonTag += ",omitempty"
+	}
+
 	return jsonTag + "\"`"
 }
 

--- a/internal/schema/schema.go
+++ b/internal/schema/schema.go
@@ -389,7 +389,7 @@ func (s *Schema) GetQueryArg(field Field) QueryArg {
 }
 
 // GetQueryStringForMutation packs a nerdgraph query header and footer around the set of query fields GraphQL mutation name.
-func (s *Schema) GetQueryStringForMutation(mutation *Field, depth int, requireFields []string) string {
+func (s *Schema) GetQueryStringForMutation(mutation *Field, depth int, argTypeOverrides map[string]string) string {
 	log.WithFields(log.Fields{
 		"depth": depth,
 		"name":  mutation.Name,
@@ -407,8 +407,8 @@ func (s *Schema) GetQueryStringForMutation(mutation *Field, depth int, requireFi
 
 	for _, a := range mutation.Args {
 		arg := s.GetQueryArg(a)
-		if arg.Value[len(arg.Value)-1:] != "!" && stringInStrings(arg.Key, requireFields) {
-			arg.Value += "!"
+		if v, ok := argTypeOverrides[arg.Key]; ok {
+			arg.Value = v
 		}
 		data.Args = append(data.Args, arg)
 	}

--- a/internal/schema/schema.go
+++ b/internal/schema/schema.go
@@ -374,7 +374,7 @@ func (s *Schema) GetQueryArg(field Field) QueryArg {
 }
 
 // GetQueryStringForMutation packs a nerdgraph query header and footer around the set of query fields GraphQL mutation name.
-func (s *Schema) GetQueryStringForMutation(mutation *Field, depth int) string {
+func (s *Schema) GetQueryStringForMutation(mutation *Field, depth int, requireFields []string) string {
 	log.WithFields(log.Fields{
 		"depth": depth,
 		"name":  mutation.Name,
@@ -391,7 +391,11 @@ func (s *Schema) GetQueryStringForMutation(mutation *Field, depth int) string {
 	}
 
 	for _, a := range mutation.Args {
-		data.Args = append(data.Args, s.GetQueryArg(a))
+		arg := s.GetQueryArg(a)
+		if arg.Value[len(arg.Value)-1:] != "!" && stringInStrings(arg.Key, requireFields) {
+			arg.Value += "!"
+		}
+		data.Args = append(data.Args, arg)
 	}
 
 	data.Fields = PrefixLineTab(fieldType.GetQueryStringFields(s, 0, depth, true))

--- a/internal/schema/schema_test.go
+++ b/internal/schema/schema_test.go
@@ -222,14 +222,20 @@ func TestSchema_GetQueryStringForMutation(t *testing.T) {
 	cases := map[string]struct {
 		Mutation string
 		Depth    int
+		Require  []string
 	}{
 		"alertsMutingRuleCreate": {
 			Mutation: "alertsMutingRuleCreate",
 			Depth:    3,
+			Require:  []string{},
 		},
 		"cloudRenameAccount": {
 			Mutation: "cloudRenameAccount",
 			Depth:    1,
+			Require: []string{
+				"accountId",
+				"accounts",
+			},
 		},
 	}
 
@@ -238,7 +244,7 @@ func TestSchema_GetQueryStringForMutation(t *testing.T) {
 		field, err := s.LookupMutationByName(tc.Mutation)
 		require.NoError(t, err)
 
-		result := s.GetQueryStringForMutation(field, tc.Depth)
+		result := s.GetQueryStringForMutation(field, tc.Depth, tc.Require)
 		// saveFixture(t, n, result)
 		expected := loadFixture(t, n)
 		assert.Equal(t, expected, result)

--- a/internal/schema/schema_test.go
+++ b/internal/schema/schema_test.go
@@ -222,19 +222,19 @@ func TestSchema_GetQueryStringForMutation(t *testing.T) {
 	cases := map[string]struct {
 		Mutation string
 		Depth    int
-		Require  []string
+		Override map[string]string
 	}{
 		"alertsMutingRuleCreate": {
 			Mutation: "alertsMutingRuleCreate",
 			Depth:    3,
-			Require:  []string{},
+			Override: map[string]string{},
 		},
 		"cloudRenameAccount": {
 			Mutation: "cloudRenameAccount",
 			Depth:    1,
-			Require: []string{
-				"accountId",
-				"accounts",
+			Override: map[string]string{
+				"accountId": "Int!",
+				"accounts":  "[CloudRenameAccountsInput!]!",
 			},
 		},
 	}
@@ -244,7 +244,7 @@ func TestSchema_GetQueryStringForMutation(t *testing.T) {
 		field, err := s.LookupMutationByName(tc.Mutation)
 		require.NoError(t, err)
 
-		result := s.GetQueryStringForMutation(field, tc.Depth, tc.Require)
+		result := s.GetQueryStringForMutation(field, tc.Depth, tc.Override)
 		// saveFixture(t, n, result)
 		expected := loadFixture(t, n)
 		assert.Equal(t, expected, result)

--- a/internal/schema/testdata/TestSchema_GetQueryStringForEndpoint_entitySearch.txt
+++ b/internal/schema/testdata/TestSchema_GetQueryStringForEndpoint_entitySearch.txt
@@ -2,10 +2,6 @@ query(
 ) { actor { entitySearch(
 ) {
 	count
-	counts {
-		count
-		facet
-	}
 	query
 	results {
 		entities {

--- a/internal/schema/testdata/TestSchema_GetQueryStringForMutation_cloudRenameAccount.txt
+++ b/internal/schema/testdata/TestSchema_GetQueryStringForMutation_cloudRenameAccount.txt
@@ -1,6 +1,6 @@
 mutation(
 	$accountId: Int!,
-	$accounts: [CloudRenameAccountsInput]!,
+	$accounts: [CloudRenameAccountsInput!]!,
 ) { cloudRenameAccount(
 	accountId: $accountId,
 	accounts: $accounts,

--- a/internal/schema/testdata/TestSchema_GetQueryStringForMutation_cloudRenameAccount.txt
+++ b/internal/schema/testdata/TestSchema_GetQueryStringForMutation_cloudRenameAccount.txt
@@ -1,6 +1,6 @@
 mutation(
-	$accountId: Int,
-	$accounts: [CloudRenameAccountsInput],
+	$accountId: Int!,
+	$accounts: [CloudRenameAccountsInput]!,
 ) { cloudRenameAccount(
 	accountId: $accountId,
 	accounts: $accounts,

--- a/internal/schema/testdata/TestType_GetQueryFieldsString_CloudDisableIntegrationPayload.txt
+++ b/internal/schema/testdata/TestType_GetQueryFieldsString_CloudDisableIntegrationPayload.txt
@@ -1,0 +1,684 @@
+disabledIntegrations {
+	__typename
+	createdAt
+	id
+	name
+	nrAccountId
+	updatedAt
+	... on CloudAlbIntegration {
+		__typename
+		awsRegions
+		fetchExtendedInventory
+		fetchTags
+		inventoryPollingInterval
+		loadBalancerPrefixes
+		metricsPollingInterval
+		tagKey
+		tagValue
+	}
+	... on CloudApigatewayIntegration {
+		__typename
+		awsRegions
+		inventoryPollingInterval
+		metricsPollingInterval
+		stagePrefixes
+		tagKey
+		tagValue
+	}
+	... on CloudAutoscalingIntegration {
+		__typename
+		awsRegions
+		inventoryPollingInterval
+		metricsPollingInterval
+	}
+	... on CloudAwsAppsyncIntegration {
+		__typename
+		awsRegions
+		inventoryPollingInterval
+		metricsPollingInterval
+	}
+	... on CloudAwsAthenaIntegration {
+		__typename
+		awsRegions
+		inventoryPollingInterval
+		metricsPollingInterval
+	}
+	... on CloudAwsCognitoIntegration {
+		__typename
+		awsRegions
+		inventoryPollingInterval
+		metricsPollingInterval
+	}
+	... on CloudAwsConnectIntegration {
+		__typename
+		awsRegions
+		inventoryPollingInterval
+		metricsPollingInterval
+	}
+	... on CloudAwsDirectconnectIntegration {
+		__typename
+		awsRegions
+		inventoryPollingInterval
+		metricsPollingInterval
+	}
+	... on CloudAwsDocdbIntegration {
+		__typename
+		awsRegions
+		inventoryPollingInterval
+		metricsPollingInterval
+	}
+	... on CloudAwsFsxIntegration {
+		__typename
+		awsRegions
+		inventoryPollingInterval
+		metricsPollingInterval
+	}
+	... on CloudAwsGlueIntegration {
+		__typename
+		awsRegions
+		inventoryPollingInterval
+		metricsPollingInterval
+	}
+	... on CloudAwsKinesisanalyticsIntegration {
+		__typename
+		awsRegions
+		inventoryPollingInterval
+		metricsPollingInterval
+	}
+	... on CloudAwsMediaconvertIntegration {
+		__typename
+		awsRegions
+		inventoryPollingInterval
+		metricsPollingInterval
+	}
+	... on CloudAwsMediapackagevodIntegration {
+		__typename
+		awsRegions
+		inventoryPollingInterval
+		metricsPollingInterval
+	}
+	... on CloudAwsMqIntegration {
+		__typename
+		awsRegions
+		inventoryPollingInterval
+		metricsPollingInterval
+	}
+	... on CloudAwsMskIntegration {
+		__typename
+		awsRegions
+		inventoryPollingInterval
+		metricsPollingInterval
+	}
+	... on CloudAwsNeptuneIntegration {
+		__typename
+		awsRegions
+		inventoryPollingInterval
+		metricsPollingInterval
+	}
+	... on CloudAwsQldbIntegration {
+		__typename
+		awsRegions
+		inventoryPollingInterval
+		metricsPollingInterval
+	}
+	... on CloudAwsRoute53resolverIntegration {
+		__typename
+		awsRegions
+		inventoryPollingInterval
+		metricsPollingInterval
+	}
+	... on CloudAwsStatesIntegration {
+		__typename
+		awsRegions
+		inventoryPollingInterval
+		metricsPollingInterval
+	}
+	... on CloudAwsTransitgatewayIntegration {
+		__typename
+		awsRegions
+		inventoryPollingInterval
+		metricsPollingInterval
+	}
+	... on CloudAwsWafIntegration {
+		__typename
+		awsRegions
+		inventoryPollingInterval
+		metricsPollingInterval
+	}
+	... on CloudAwsWafv2Integration {
+		__typename
+		awsRegions
+		inventoryPollingInterval
+		metricsPollingInterval
+	}
+	... on CloudAwsXrayIntegration {
+		__typename
+		awsRegions
+		inventoryPollingInterval
+		metricsPollingInterval
+	}
+	... on CloudAzureApimanagementIntegration {
+		__typename
+		inventoryPollingInterval
+		metricsPollingInterval
+		resourceGroups
+	}
+	... on CloudAzureAppgatewayIntegration {
+		__typename
+		inventoryPollingInterval
+		metricsPollingInterval
+		resourceGroups
+	}
+	... on CloudAzureAppserviceIntegration {
+		__typename
+		inventoryPollingInterval
+		metricsPollingInterval
+		resourceGroups
+	}
+	... on CloudAzureContainersIntegration {
+		__typename
+		inventoryPollingInterval
+		metricsPollingInterval
+		resourceGroups
+	}
+	... on CloudAzureCosmosdbIntegration {
+		__typename
+		inventoryPollingInterval
+		metricsPollingInterval
+		resourceGroups
+	}
+	... on CloudAzureCostmanagementIntegration {
+		__typename
+		inventoryPollingInterval
+		metricsPollingInterval
+		tagKeys
+	}
+	... on CloudAzureDatafactoryIntegration {
+		__typename
+		inventoryPollingInterval
+		metricsPollingInterval
+		resourceGroups
+	}
+	... on CloudAzureEventhubIntegration {
+		__typename
+		inventoryPollingInterval
+		metricsPollingInterval
+		resourceGroups
+	}
+	... on CloudAzureExpressrouteIntegration {
+		__typename
+		inventoryPollingInterval
+		metricsPollingInterval
+		resourceGroups
+	}
+	... on CloudAzureFirewallsIntegration {
+		__typename
+		inventoryPollingInterval
+		metricsPollingInterval
+		resourceGroups
+	}
+	... on CloudAzureFrontdoorIntegration {
+		__typename
+		inventoryPollingInterval
+		metricsPollingInterval
+		resourceGroups
+	}
+	... on CloudAzureFunctionsIntegration {
+		__typename
+		inventoryPollingInterval
+		metricsPollingInterval
+		resourceGroups
+	}
+	... on CloudAzureKeyvaultIntegration {
+		__typename
+		inventoryPollingInterval
+		metricsPollingInterval
+		resourceGroups
+	}
+	... on CloudAzureLoadbalancerIntegration {
+		__typename
+		inventoryPollingInterval
+		metricsPollingInterval
+		resourceGroups
+	}
+	... on CloudAzureLogicappsIntegration {
+		__typename
+		inventoryPollingInterval
+		metricsPollingInterval
+		resourceGroups
+	}
+	... on CloudAzureMachinelearningIntegration {
+		__typename
+		inventoryPollingInterval
+		metricsPollingInterval
+		resourceGroups
+	}
+	... on CloudAzureMariadbIntegration {
+		__typename
+		inventoryPollingInterval
+		metricsPollingInterval
+		resourceGroups
+	}
+	... on CloudAzureMysqlIntegration {
+		__typename
+		inventoryPollingInterval
+		metricsPollingInterval
+		resourceGroups
+	}
+	... on CloudAzurePostgresqlIntegration {
+		__typename
+		inventoryPollingInterval
+		metricsPollingInterval
+		resourceGroups
+	}
+	... on CloudAzurePowerbidedicatedIntegration {
+		__typename
+		inventoryPollingInterval
+		metricsPollingInterval
+		resourceGroups
+	}
+	... on CloudAzureRediscacheIntegration {
+		__typename
+		inventoryPollingInterval
+		metricsPollingInterval
+		resourceGroups
+	}
+	... on CloudAzureServicebusIntegration {
+		__typename
+		inventoryPollingInterval
+		metricsPollingInterval
+		resourceGroups
+	}
+	... on CloudAzureServicefabricIntegration {
+		__typename
+		inventoryPollingInterval
+		metricsPollingInterval
+		resourceGroups
+	}
+	... on CloudAzureSqlIntegration {
+		__typename
+		inventoryPollingInterval
+		metricsPollingInterval
+		resourceGroups
+	}
+	... on CloudAzureSqlmanagedIntegration {
+		__typename
+		inventoryPollingInterval
+		metricsPollingInterval
+		resourceGroups
+	}
+	... on CloudAzureStorageIntegration {
+		__typename
+		inventoryPollingInterval
+		metricsPollingInterval
+		resourceGroups
+	}
+	... on CloudAzureVirtualmachineIntegration {
+		__typename
+		inventoryPollingInterval
+		metricsPollingInterval
+		resourceGroups
+	}
+	... on CloudAzureVirtualnetworksIntegration {
+		__typename
+		inventoryPollingInterval
+		metricsPollingInterval
+		resourceGroups
+	}
+	... on CloudAzureVmsIntegration {
+		__typename
+		inventoryPollingInterval
+		metricsPollingInterval
+		resourceGroups
+	}
+	... on CloudAzureVpngatewaysIntegration {
+		__typename
+		inventoryPollingInterval
+		metricsPollingInterval
+		resourceGroups
+	}
+	... on CloudBaseIntegration {
+		__typename
+	}
+	... on CloudBillingIntegration {
+		__typename
+		inventoryPollingInterval
+		metricsPollingInterval
+	}
+	... on CloudCloudfrontIntegration {
+		__typename
+		fetchLambdasAtEdge
+		fetchTags
+		inventoryPollingInterval
+		metricsPollingInterval
+		tagKey
+		tagValue
+	}
+	... on CloudCloudtrailIntegration {
+		__typename
+		awsRegions
+		inventoryPollingInterval
+		metricsPollingInterval
+	}
+	... on CloudDynamodbIntegration {
+		__typename
+		awsRegions
+		fetchExtendedInventory
+		fetchTags
+		inventoryPollingInterval
+		metricsPollingInterval
+		tagKey
+		tagValue
+	}
+	... on CloudEbsIntegration {
+		__typename
+		awsRegions
+		fetchExtendedInventory
+		inventoryPollingInterval
+		metricsPollingInterval
+		tagKey
+		tagValue
+	}
+	... on CloudEc2Integration {
+		__typename
+		awsRegions
+		fetchIpAddresses
+		inventoryPollingInterval
+		metricsPollingInterval
+		tagKey
+		tagValue
+	}
+	... on CloudEcsIntegration {
+		__typename
+		awsRegions
+		fetchTags
+		inventoryPollingInterval
+		metricsPollingInterval
+		tagKey
+		tagValue
+	}
+	... on CloudEfsIntegration {
+		__typename
+		awsRegions
+		fetchTags
+		inventoryPollingInterval
+		metricsPollingInterval
+		tagKey
+		tagValue
+	}
+	... on CloudElasticacheIntegration {
+		__typename
+		awsRegions
+		fetchTags
+		inventoryPollingInterval
+		metricsPollingInterval
+		tagKey
+		tagValue
+	}
+	... on CloudElasticbeanstalkIntegration {
+		__typename
+		awsRegions
+		fetchExtendedInventory
+		fetchTags
+		inventoryPollingInterval
+		metricsPollingInterval
+		tagKey
+		tagValue
+	}
+	... on CloudElasticsearchIntegration {
+		__typename
+		awsRegions
+		fetchNodes
+		inventoryPollingInterval
+		metricsPollingInterval
+		tagKey
+		tagValue
+	}
+	... on CloudElbIntegration {
+		__typename
+		awsRegions
+		fetchExtendedInventory
+		fetchTags
+		inventoryPollingInterval
+		metricsPollingInterval
+	}
+	... on CloudEmrIntegration {
+		__typename
+		awsRegions
+		fetchTags
+		inventoryPollingInterval
+		metricsPollingInterval
+		tagKey
+		tagValue
+	}
+	... on CloudGcpAppengineIntegration {
+		__typename
+		inventoryPollingInterval
+		metricsPollingInterval
+	}
+	... on CloudGcpBigqueryIntegration {
+		__typename
+		fetchTags
+		inventoryPollingInterval
+		metricsPollingInterval
+	}
+	... on CloudGcpDataflowIntegration {
+		__typename
+		inventoryPollingInterval
+		metricsPollingInterval
+	}
+	... on CloudGcpDataprocIntegration {
+		__typename
+		inventoryPollingInterval
+		metricsPollingInterval
+	}
+	... on CloudGcpDatastoreIntegration {
+		__typename
+		inventoryPollingInterval
+		metricsPollingInterval
+	}
+	... on CloudGcpFirebasedatabaseIntegration {
+		__typename
+		inventoryPollingInterval
+		metricsPollingInterval
+	}
+	... on CloudGcpFirebasehostingIntegration {
+		__typename
+		inventoryPollingInterval
+		metricsPollingInterval
+	}
+	... on CloudGcpFirebasestorageIntegration {
+		__typename
+		inventoryPollingInterval
+		metricsPollingInterval
+	}
+	... on CloudGcpFirestoreIntegration {
+		__typename
+		inventoryPollingInterval
+		metricsPollingInterval
+	}
+	... on CloudGcpFunctionsIntegration {
+		__typename
+		inventoryPollingInterval
+		metricsPollingInterval
+	}
+	... on CloudGcpInterconnectIntegration {
+		__typename
+		inventoryPollingInterval
+		metricsPollingInterval
+	}
+	... on CloudGcpKubernetesIntegration {
+		__typename
+		inventoryPollingInterval
+		metricsPollingInterval
+	}
+	... on CloudGcpLoadbalancingIntegration {
+		__typename
+		inventoryPollingInterval
+		metricsPollingInterval
+	}
+	... on CloudGcpPubsubIntegration {
+		__typename
+		fetchTags
+		inventoryPollingInterval
+		metricsPollingInterval
+	}
+	... on CloudGcpRouterIntegration {
+		__typename
+		inventoryPollingInterval
+		metricsPollingInterval
+	}
+	... on CloudGcpRunIntegration {
+		__typename
+		inventoryPollingInterval
+		metricsPollingInterval
+	}
+	... on CloudGcpSpannerIntegration {
+		__typename
+		fetchTags
+		inventoryPollingInterval
+		metricsPollingInterval
+	}
+	... on CloudGcpSqlIntegration {
+		__typename
+		inventoryPollingInterval
+		metricsPollingInterval
+	}
+	... on CloudGcpStorageIntegration {
+		__typename
+		fetchTags
+		inventoryPollingInterval
+		metricsPollingInterval
+	}
+	... on CloudGcpVmsIntegration {
+		__typename
+		inventoryPollingInterval
+		metricsPollingInterval
+	}
+	... on CloudGcpVpcaccessIntegration {
+		__typename
+		inventoryPollingInterval
+		metricsPollingInterval
+	}
+	... on CloudHealthIntegration {
+		__typename
+		inventoryPollingInterval
+		metricsPollingInterval
+	}
+	... on CloudIamIntegration {
+		__typename
+		inventoryPollingInterval
+		metricsPollingInterval
+		tagKey
+		tagValue
+	}
+	... on CloudIotIntegration {
+		__typename
+		awsRegions
+		inventoryPollingInterval
+		metricsPollingInterval
+	}
+	... on CloudKinesisFirehoseIntegration {
+		__typename
+		awsRegions
+		inventoryPollingInterval
+		metricsPollingInterval
+	}
+	... on CloudKinesisIntegration {
+		__typename
+		awsRegions
+		fetchShards
+		fetchTags
+		inventoryPollingInterval
+		metricsPollingInterval
+		tagKey
+		tagValue
+	}
+	... on CloudLambdaIntegration {
+		__typename
+		awsRegions
+		fetchTags
+		inventoryPollingInterval
+		metricsPollingInterval
+		tagKey
+		tagValue
+	}
+	... on CloudRdsIntegration {
+		__typename
+		awsRegions
+		fetchTags
+		inventoryPollingInterval
+		metricsPollingInterval
+		tagKey
+		tagValue
+	}
+	... on CloudRedshiftIntegration {
+		__typename
+		awsRegions
+		inventoryPollingInterval
+		metricsPollingInterval
+		tagKey
+		tagValue
+	}
+	... on CloudRoute53Integration {
+		__typename
+		fetchExtendedInventory
+		inventoryPollingInterval
+		metricsPollingInterval
+	}
+	... on CloudS3Integration {
+		__typename
+		fetchExtendedInventory
+		fetchTags
+		inventoryPollingInterval
+		metricsPollingInterval
+		tagKey
+		tagValue
+	}
+	... on CloudSesIntegration {
+		__typename
+		awsRegions
+		inventoryPollingInterval
+		metricsPollingInterval
+	}
+	... on CloudSnsIntegration {
+		__typename
+		awsRegions
+		fetchExtendedInventory
+		inventoryPollingInterval
+		metricsPollingInterval
+	}
+	... on CloudSqsIntegration {
+		__typename
+		awsRegions
+		fetchExtendedInventory
+		fetchTags
+		inventoryPollingInterval
+		metricsPollingInterval
+		queuePrefixes
+		tagKey
+		tagValue
+	}
+	... on CloudTrustedadvisorIntegration {
+		__typename
+		inventoryPollingInterval
+		metricsPollingInterval
+	}
+	... on CloudVpcIntegration {
+		__typename
+		awsRegions
+		fetchNatGateway
+		fetchVpn
+		inventoryPollingInterval
+		metricsPollingInterval
+		tagKey
+		tagValue
+	}
+}
+errors {
+	integrationSlug
+	linkedAccountId
+	message
+	nrAccountId
+	type
+}

--- a/internal/schema/type_test.go
+++ b/internal/schema/type_test.go
@@ -41,6 +41,11 @@ func TestType_GetQueryFieldsString(t *testing.T) {
 			Depth:    3,
 			Mutation: false,
 		},
+		"CloudDisableIntegrationPayload": {
+			TypeName: "CloudDisableIntegrationPayload",
+			Depth:    1,
+			Mutation: true,
+		},
 	}
 
 	for n, tc := range cases {

--- a/internal/schema/type_test.go
+++ b/internal/schema/type_test.go
@@ -19,22 +19,27 @@ func TestType_GetQueryFieldsString(t *testing.T) {
 	cases := map[string]struct {
 		TypeName string
 		Depth    int
+		Mutation bool
 	}{
 		"AlertsNrqlCondition": {
 			TypeName: "AlertsNrqlCondition",
 			Depth:    2,
+			Mutation: false,
 		},
 		"AlertsNrqlBaselineCondition": {
 			TypeName: "AlertsNrqlBaselineCondition",
 			Depth:    2,
+			Mutation: false,
 		},
 		"AlertsNrqlOutlierCondition": {
 			TypeName: "AlertsNrqlOutlierCondition",
 			Depth:    2,
+			Mutation: false,
 		},
 		"CloudLinkedAccount": {
 			TypeName: "CloudLinkedAccount",
 			Depth:    3,
+			Mutation: false,
 		},
 	}
 
@@ -42,7 +47,7 @@ func TestType_GetQueryFieldsString(t *testing.T) {
 		x, err := s.LookupTypeByName(tc.TypeName)
 		require.NoError(t, err)
 
-		xx := x.GetQueryStringFields(s, 0, tc.Depth)
+		xx := x.GetQueryStringFields(s, 0, tc.Depth, tc.Mutation)
 		// saveFixture(t, n, xx)
 		expected := loadFixture(t, n)
 		assert.Equal(t, expected, xx)

--- a/internal/schema/typeref.go
+++ b/internal/schema/typeref.go
@@ -16,17 +16,6 @@ type TypeRef struct {
 	OfType *TypeRef `json:"ofType,omitempty"`
 }
 
-// IsList determines if a TypeRef is of a KIND LIST.
-func (r *TypeRef) IsList() bool {
-	kinds := r.GetKinds()
-
-	if len(kinds) > 0 && kinds[0] == KindList {
-		return true
-	}
-
-	return false
-}
-
 // GetKinds returns an array or the type kind
 func (r *TypeRef) GetKinds() []Kind {
 	tree := []Kind{}
@@ -104,12 +93,11 @@ func (r *TypeRef) GetDescription() string {
 func (r *TypeRef) IsInputObject() bool {
 	kinds := r.GetKinds()
 
-	if len(kinds) > 0 && kinds[0] == KindInputObject {
-		return true
-	}
-
-	if r.OfType != nil && r.OfType.Kind == KindInputObject {
-		return true
+	// Lots of kinds
+	for _, k := range kinds {
+		if k == KindInputObject {
+			return true
+		}
 	}
 
 	return false
@@ -120,5 +108,42 @@ func (r *TypeRef) IsScalarID() bool {
 }
 
 func (r *TypeRef) IsNonNull() bool {
-	return r.Kind == KindNonNull
+	kinds := r.GetKinds()
+
+	// Lots of kinds
+	for _, k := range kinds {
+		if k == KindNonNull {
+			return true
+		}
+	}
+
+	return false
+}
+
+// IsList determines if a TypeRef is of a KIND LIST.
+func (r *TypeRef) IsList() bool {
+	kinds := r.GetKinds()
+
+	// Lots of kinds
+	for _, k := range kinds {
+		if k == KindList {
+			return true
+		}
+	}
+
+	return false
+}
+
+// IsList determines if a TypeRef is of a KIND INTERFACE.
+func (r *TypeRef) IsInterface() bool {
+	kinds := r.GetKinds()
+
+	// Lots of kinds
+	for _, k := range kinds {
+		if k == KindInterface {
+			return true
+		}
+	}
+
+	return false
 }

--- a/internal/schema/typeref.go
+++ b/internal/schema/typeref.go
@@ -107,6 +107,28 @@ func (r *TypeRef) IsScalarID() bool {
 	return r.OfType != nil && r.OfType.Kind == KindScalar && r.GetTypeName() == "ID"
 }
 
+// IsNonNull walks down looking for NON_NULL kind, however that can appear
+// multiple times, so this is likely a bit deceiving...
+// Example:
+// {
+//    "name": "tags",
+//    "description": "An array of key-values pairs to represent a tag. For example:  Team:TeamName.",
+//    "type": {
+//     "kind": "NON_NULL",
+//     "ofType": {
+//      "kind": "LIST",
+//      "ofType": {
+//       "kind": "NON_NULL",
+//       "ofType": {
+//        "name": "TaggingTagInput",
+//        "kind": "INPUT_OBJECT"
+//       }
+//      }
+//     }
+//    }
+//   }
+//  ]
+// }
 func (r *TypeRef) IsNonNull() bool {
 	kinds := r.GetKinds()
 

--- a/pkg/lang/golang.go
+++ b/pkg/lang/golang.go
@@ -229,7 +229,7 @@ func GenerateGoMethodMutationsForPackage(s *schema.Schema, genConfig *config.Gen
 		}
 
 		method := goMethodForField(*field, pkgConfig, nil)
-		method.QueryString = s.GetQueryStringForMutation(field, pkgMutation.MaxQueryFieldDepth)
+		method.QueryString = s.GetQueryStringForMutation(field, pkgMutation.MaxQueryFieldDepth, pkgMutation.RequireFields)
 
 		methods = append(methods, method)
 	}

--- a/pkg/lang/golang.go
+++ b/pkg/lang/golang.go
@@ -229,7 +229,7 @@ func GenerateGoMethodMutationsForPackage(s *schema.Schema, genConfig *config.Gen
 		}
 
 		method := goMethodForField(*field, pkgConfig, nil)
-		method.QueryString = s.GetQueryStringForMutation(field, pkgMutation.MaxQueryFieldDepth, pkgMutation.RequireFields)
+		method.QueryString = s.GetQueryStringForMutation(field, pkgMutation.MaxQueryFieldDepth, pkgMutation.ArgumentTypeOverrides)
 
 		methods = append(methods, method)
 	}


### PR DESCRIPTION
* Cleanup use of GetTypes + range loops in favor of helper functions
* For auto-generated GraphQL queries, if a parent field has children, and all of those children require arguments, then skip the parent field. This caused issues when generating Entity, as `nerdStorage` is a first level field, and all of it's children require args, so the generated query was invalid.
* Enable overriding of a mutation field completely, given any field name, you specify what we generate for the Mutation. This allows work-around for schema issues where the expect types / non-nulls do not match the introspection.