### PR TITLE
refactor: Replace IncludeNullable with a list of arguments to add

### DIFF
--- a/configs/tutone.yml
+++ b/configs/tutone.yml
@@ -50,7 +50,8 @@ packages:
         endpoints:
           - name: linkedAccounts
             max_query_field_depth: 2
-            include_nullable: true
+            include_arguments:
+              - "provider"
     mutations:
       - name: cloudConfigureIntegration
       - name: cloudDisableIntegration

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -118,9 +118,9 @@ type MutationConfig struct {
 }
 
 type EndpointConfig struct {
-	Name               string `yaml:"name,omitempty"`
-	MaxQueryFieldDepth int    `yaml:"max_query_field_depth,omitempty"`
-	IncludeNullable    bool   `yaml:"include_nullable,omitempty"`
+	Name               string   `yaml:"name,omitempty"`
+	MaxQueryFieldDepth int      `yaml:"max_query_field_depth,omitempty"`
+	IncludeArguments   []string `yaml:"include_arguments,omitempty"`
 }
 
 // TypeConfig is the information about which types to render and any data specific to handling of the type.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -60,7 +60,7 @@ func TestLoadConfig(t *testing.T) {
 							{
 								Name:               "linkedAccounts",
 								MaxQueryFieldDepth: 2,
-								IncludeNullable:    true,
+								IncludeArguments:   []string{"provider"},
 							},
 						},
 					},

--- a/pkg/lang/golang.go
+++ b/pkg/lang/golang.go
@@ -187,7 +187,7 @@ func GenerateGoMethodQueriesForPackage(s *schema.Schema, genConfig *config.Gener
 
 					method := goMethodForField(field, pkgConfig, inputFields)
 
-					method.QueryString = s.GetQueryStringForEndpoint(typePath, pkgQuery.Path, endpoint.Name, endpoint.MaxQueryFieldDepth, endpoint.IncludeNullable)
+					method.QueryString = s.GetQueryStringForEndpoint(typePath, pkgQuery.Path, endpoint.Name, endpoint.MaxQueryFieldDepth, endpoint.IncludeArguments)
 					method.ResponseObjectType = fmt.Sprintf("%sResponse", endpoint.Name)
 					method.Signature.ReturnPath = returnPath
 

--- a/testdata/goodConfig_fixture.yml
+++ b/testdata/goodConfig_fixture.yml
@@ -17,7 +17,8 @@ packages:
         endpoints:
           - name: linkedAccounts
             max_query_field_depth: 2
-            include_nullable: true
+            include_arguments:
+              - "provider"
     types:
       - name: AlertsMutingRuleConditionInput
       - name: ID


### PR DESCRIPTION
Currently IncludeNullable includes all of the nullable args, which doesn't work if you need one arg out of the set.  This changes the logic to require an explicit list of args that are nullable to add.  Required args are still added no matter what.