### PR TITLE
Endpoint for a query might not take args

### DIFF
--- a/internal/schema/schema.go
+++ b/internal/schema/schema.go
@@ -468,11 +468,12 @@ var queryHeaderTemplate = `query(
 	{{- range .QueryArgs}}
 	${{.Key}}: {{.Value}},
 	{{- end}}
-) { {{ .FieldPath | join " { " }} { {{.Endpoint}}(
-	{{- range .EndpointArgs}}
+) { {{ .FieldPath | join " { " }} { {{.Endpoint}}
+  {{- if .EndpointArgs }}(
+	{{-   range .EndpointArgs}}
 	{{.Key}}: ${{.Key}},
-	{{- end}}
-) {
+	{{-   end}}
+){{- end}} {
 {{.Fields}}
 `
 

--- a/internal/schema/schema_test.go
+++ b/internal/schema/schema_test.go
@@ -188,6 +188,12 @@ func TestSchema_GetQueryStringForEndpoint(t *testing.T) {
 			Field: "entitySearch",
 			Depth: 3,
 		},
+		"entitySearchArgs": {
+			Path:        []string{"actor"},
+			Field:       "entitySearch",
+			Depth:       3,
+			IncludeArgs: []string{"query"},
+		},
 		"entities": {
 			Path:  []string{"actor"},
 			Field: "entities",

--- a/internal/schema/testdata/TestSchema_GetQueryStringForEndpoint_entitySearchArgs.txt
+++ b/internal/schema/testdata/TestSchema_GetQueryStringForEndpoint_entitySearchArgs.txt
@@ -1,5 +1,8 @@
 query(
-) { actor { entitySearch {
+	$query: String,
+) { actor { entitySearch(
+	query: $query,
+) {
 	count
 	query
 	results {


### PR DESCRIPTION
It is currently assumed that the Endpoint of a query requires arguments.  If you're looking to get a subset of data within an Endpoint that filters, that is not the case.  Example is fetching Tags from an entity.  We correctly build the path with `entity` requiring a `GUID`, but `tags` has no arguments, thus we generate a broken query:

```
query(
       $entityGUID: EntityGuid!,
) { actor { entity(guid: $entityGUID) { tags(
) {
       key
       values
} } } }
```

This update resolves by only adding `( ... )` to the Endpoint if there are arguments, and generates the following output for the example `tags`:

```
query(
       $entityGUID: EntityGuid!,
) { actor { entity(guid: $entityGUID) { tags {
       key
       values
} } } }
```