### PR TITLE
docs: Fix repository URL in changelog

### DIFF
--- a/.chglog/config.yml
+++ b/.chglog/config.yml
@@ -2,7 +2,7 @@ style: github
 template: CHANGELOG.tpl.md
 info:
   title: CHANGELOG
-  repository_url: https://github.com/newrelic/newrelic-client-go
+  repository_url: https://github.com/newrelic/tutone
 options:
   commits:
     filters:


### PR DESCRIPTION
Hello,

I was reading this project [changelog](https://github.com/newrelic/tutone/blob/v0.5.0/CHANGELOG.md) and noticed that the version comparison links points to [newrelic-client-go](https://github.com/newrelic/newrelic-client-go) repository.

Let me know if this PR is ok or if something is missing.

Thanks