### PR TITLE
Allow for mutations to be matched by regexp

### DIFF
--- a/internal/schema/schema.go
+++ b/internal/schema/schema.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
+	"regexp"
 	"strings"
 	"text/template"
 
@@ -162,6 +163,8 @@ func (s *Schema) LookupTypeByName(typeName string) (*Type, error) {
 	return nil, fmt.Errorf("type by name %s not found", typeName)
 }
 
+// LookupMutationByName searches for the specific mutation by name and returns
+// a reference if found.
 func (s *Schema) LookupMutationByName(mutationName string) (*Field, error) {
 	for _, f := range s.MutationType.Fields {
 		if f.Name == mutationName {
@@ -170,6 +173,19 @@ func (s *Schema) LookupMutationByName(mutationName string) (*Field, error) {
 	}
 
 	return nil, fmt.Errorf("mutation by name %s not found", mutationName)
+}
+
+// LookupMutationsByPattern finds all matching mutations given the regexp
+func (s *Schema) LookupMutationsByPattern(pattern string) []Field {
+	var ret []Field
+
+	for _, f := range s.MutationType.Fields {
+		if found, _ := regexp.MatchString(pattern, f.Name); found {
+			ret = append(ret, f)
+		}
+	}
+
+	return ret
 }
 
 // LookupQueryTypesByFieldPath is used to retrieve the types, when all you know is

--- a/internal/schema/schema_test.go
+++ b/internal/schema/schema_test.go
@@ -293,6 +293,38 @@ func TestSchema_GetQueryStringForMutation(t *testing.T) {
 	}
 }
 
+func TestSchema_GetQueryStringForMutation_Pattern(t *testing.T) {
+	t.Parallel()
+
+	// schema cached by 'make test-prep'
+	s, err := Load("../../testdata/schema.json")
+	require.NoError(t, err)
+
+	cases := []config.MutationConfig{
+		{
+			Name:                  "alertsMutingRuleCreate",
+			MaxQueryFieldDepth:    3,
+			ArgumentTypeOverrides: map[string]string{},
+		},
+		{
+			Name:               "edge.*",
+			MaxQueryFieldDepth: 3,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Logf("TestCase: %s", tc.Name)
+		fields := s.LookupMutationsByPattern(tc.Name)
+
+		for _, field := range fields {
+			result := s.GetQueryStringForMutation(&field, tc)
+			// saveFixture(t, field.Name, result)
+			expected := loadFixture(t, field.Name)
+			assert.Equal(t, expected, result)
+		}
+	}
+}
+
 func TestSchema_GetInputFieldsForQueryPath(t *testing.T) {
 	t.Parallel()
 

--- a/internal/schema/schema_util.go
+++ b/internal/schema/schema_util.go
@@ -73,7 +73,7 @@ func typeNameInTypes(s string, types []config.TypeConfig) bool {
 // mutationNameInMutations determines if a name is already present in a set of config.MutationConfig.
 func mutationNameInMutations(s string, mutations []config.MutationConfig) bool {
 	for _, t := range mutations {
-		if t.Name == s {
+		if found, _ := regexp.MatchString(t.Name, s); found {
 			return true
 		}
 	}

--- a/internal/schema/schema_util_test.go
+++ b/internal/schema/schema_util_test.go
@@ -12,6 +12,67 @@ import (
 	"github.com/newrelic/tutone/internal/config"
 )
 
+func TestMutationInMutations(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]struct {
+		Name           string
+		Mutations      []config.MutationConfig
+		ExpectedResult bool
+	}{
+		"simple string": {
+			Name: "asdf",
+			Mutations: []config.MutationConfig{
+				{
+					Name: "asdf",
+				},
+			},
+			ExpectedResult: true,
+		},
+		"no match": {
+			Name: "bar",
+			Mutations: []config.MutationConfig{
+				{
+					Name: "foo",
+				},
+			},
+			ExpectedResult: false,
+		},
+		"regexp match simple": {
+			Name: "edgeCreateTraceFilterRules",
+			Mutations: []config.MutationConfig{
+				{
+					Name: "edge.*",
+				},
+			},
+			ExpectedResult: true,
+		},
+		"regexp match complex": {
+			Name: "edgeCreateTraceFilterRules",
+			Mutations: []config.MutationConfig{
+				{
+					Name: "edge(Create|Delete)TraceFilterRules",
+				},
+			},
+			ExpectedResult: true,
+		},
+		"regexp no match": {
+			Name: "bar",
+			Mutations: []config.MutationConfig{
+				{
+					Name: "/foo(Create|Delete)/",
+				},
+			},
+			ExpectedResult: false,
+		},
+	}
+
+	for caseName, tc := range cases {
+		result := mutationNameInMutations(tc.Name, tc.Mutations)
+		assert.Equal(t, tc.ExpectedResult, result, caseName)
+	}
+}
+
 func TestExpandTypes(t *testing.T) {
 	t.Parallel()
 

--- a/internal/schema/testdata/TestSchema_GetQueryStringForMutation_Pattern_alertsMutingRuleCreate.txt
+++ b/internal/schema/testdata/TestSchema_GetQueryStringForMutation_Pattern_alertsMutingRuleCreate.txt
@@ -1,0 +1,49 @@
+mutation(
+	$accountId: Int!,
+	$rule: AlertsMutingRuleInput!,
+) { alertsMutingRuleCreate(
+	accountId: $accountId,
+	rule: $rule,
+) {
+	accountId
+	condition {
+		conditions {
+			attribute
+			operator
+			values
+		}
+		operator
+	}
+	createdAt
+	createdBy
+	createdByUser {
+		email
+		gravatar
+		id
+		name
+	}
+	description
+	enabled
+	id
+	name
+	schedule {
+		endRepeat
+		endTime
+		nextEndTime
+		nextStartTime
+		repeat
+		repeatCount
+		startTime
+		timeZone
+		weeklyRepeatDays
+	}
+	status
+	updatedAt
+	updatedBy
+	updatedByUser {
+		email
+		gravatar
+		id
+		name
+	}
+} }

--- a/internal/schema/testdata/TestSchema_GetQueryStringForMutation_Pattern_edgeCreateTraceFilterRules.txt
+++ b/internal/schema/testdata/TestSchema_GetQueryStringForMutation_Pattern_edgeCreateTraceFilterRules.txt
@@ -1,0 +1,24 @@
+mutation(
+	$accountId: Int!,
+	$rules: EdgeCreateTraceFilterRulesInput!,
+	$traceObserverId: Int!,
+) { edgeCreateTraceFilterRules(
+	accountId: $accountId,
+	rules: $rules,
+	traceObserverId: $traceObserverId,
+) {
+	spanAttributeRules {
+		errors {
+			message
+			type
+		}
+		rules {
+			action
+			id
+			key
+			keyOperator
+			value
+			valueOperator
+		}
+	}
+} }

--- a/internal/schema/testdata/TestSchema_GetQueryStringForMutation_Pattern_edgeCreateTraceObserver.txt
+++ b/internal/schema/testdata/TestSchema_GetQueryStringForMutation_Pattern_edgeCreateTraceObserver.txt
@@ -1,0 +1,25 @@
+mutation(
+	$accountId: Int!,
+	$traceObserverConfigs: [EdgeCreateTraceObserverInput!]!,
+) { edgeCreateTraceObserver(
+	accountId: $accountId,
+	traceObserverConfigs: $traceObserverConfigs,
+) {
+	responses {
+		errors {
+			message
+			type
+		}
+		traceObserver {
+			endpoints {
+				endpointType
+				status
+			}
+			id
+			monitoringAccountId
+			name
+			providerRegion
+			status
+		}
+	}
+} }

--- a/internal/schema/testdata/TestSchema_GetQueryStringForMutation_Pattern_edgeDeleteTraceFilterRules.txt
+++ b/internal/schema/testdata/TestSchema_GetQueryStringForMutation_Pattern_edgeDeleteTraceFilterRules.txt
@@ -1,0 +1,24 @@
+mutation(
+	$accountId: Int!,
+	$rules: EdgeDeleteTraceFilterRulesInput!,
+	$traceObserverId: Int!,
+) { edgeDeleteTraceFilterRules(
+	accountId: $accountId,
+	rules: $rules,
+	traceObserverId: $traceObserverId,
+) {
+	spanAttributeRules {
+		errors {
+			message
+			type
+		}
+		rule {
+			action
+			id
+			key
+			keyOperator
+			value
+			valueOperator
+		}
+	}
+} }

--- a/internal/schema/testdata/TestSchema_GetQueryStringForMutation_Pattern_edgeDeleteTraceObservers.txt
+++ b/internal/schema/testdata/TestSchema_GetQueryStringForMutation_Pattern_edgeDeleteTraceObservers.txt
@@ -1,0 +1,25 @@
+mutation(
+	$accountId: Int!,
+	$traceObserverConfigs: [EdgeDeleteTraceObserverInput!]!,
+) { edgeDeleteTraceObservers(
+	accountId: $accountId,
+	traceObserverConfigs: $traceObserverConfigs,
+) {
+	responses {
+		errors {
+			message
+			type
+		}
+		traceObserver {
+			endpoints {
+				endpointType
+				status
+			}
+			id
+			monitoringAccountId
+			name
+			providerRegion
+			status
+		}
+	}
+} }

--- a/internal/schema/testdata/TestSchema_GetQueryStringForMutation_Pattern_edgeUpdateTraceObservers.txt
+++ b/internal/schema/testdata/TestSchema_GetQueryStringForMutation_Pattern_edgeUpdateTraceObservers.txt
@@ -1,0 +1,25 @@
+mutation(
+	$accountId: Int!,
+	$traceObserverConfigs: [EdgeUpdateTraceObserverInput!]!,
+) { edgeUpdateTraceObservers(
+	accountId: $accountId,
+	traceObserverConfigs: $traceObserverConfigs,
+) {
+	responses {
+		errors {
+			message
+			type
+		}
+		traceObserver {
+			endpoints {
+				endpointType
+				status
+			}
+			id
+			monitoringAccountId
+			name
+			providerRegion
+			status
+		}
+	}
+} }

--- a/pkg/lang/golang.go
+++ b/pkg/lang/golang.go
@@ -161,23 +161,15 @@ func GenerateGoMethodMutationsForPackage(s *schema.Schema, genConfig *config.Gen
 		return nil, nil
 	}
 
-	// for _, field := range s.MutationType.Fields {
 	for _, pkgMutation := range pkgConfig.Mutations {
-		field, err := s.LookupMutationByName(pkgMutation.Name)
-		if err != nil {
-			log.Error(err)
-			continue
+		fields := s.LookupMutationsByPattern(pkgMutation.Name)
+
+		for _, field := range fields {
+			method := goMethodForField(field, pkgConfig, nil)
+			method.QueryString = s.GetQueryStringForMutation(&field, pkgMutation)
+
+			methods = append(methods, method)
 		}
-
-		if field == nil {
-			log.Errorf("unable to generate mutation from nil field, %s", pkgMutation.Name)
-			continue
-		}
-
-		method := goMethodForField(*field, pkgConfig, nil)
-		method.QueryString = s.GetQueryStringForMutation(field, pkgMutation)
-
-		methods = append(methods, method)
 	}
 
 	if len(methods) > 0 {


### PR DESCRIPTION
Currently you must explicitly define all mutations to be auto-generated.  This requires constant attention as new mutations are added.  This change allows for regexp to be used in the mutation Name field and generates all matching mutation code.

Resolves #174 