### PR TITLE
chore(build): Update goreleaser docker syntax

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -49,7 +49,7 @@ dockers:
       - "newrelic/tutone:{{ .Tag }}"
       - "newrelic/tutone:v{{ .Major }}.{{ .Minor }}"
       - "newrelic/tutone:latest"
-    binaries:
+    ids:
       - tutone
     build_flag_templates:
       - "--pull"


### PR DESCRIPTION
Old syntax is deprecated: https://goreleaser.com/deprecations#dockerbinaries