### PR TITLE
fix(schema): Explicitly anchor the regexp for mutation name

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -49,7 +49,7 @@ dockers:
       - "newrelic/tutone:{{ .Tag }}"
       - "newrelic/tutone:v{{ .Major }}.{{ .Minor }}"
       - "newrelic/tutone:latest"
-    binaries:
+    ids:
       - tutone
     build_flag_templates:
       - "--pull"

--- a/internal/schema/schema.go
+++ b/internal/schema/schema.go
@@ -179,6 +179,17 @@ func (s *Schema) LookupMutationByName(mutationName string) (*Field, error) {
 func (s *Schema) LookupMutationsByPattern(pattern string) []Field {
 	var ret []Field
 
+	if len(pattern) < 1 {
+		return ret
+	}
+
+	if pattern[0] != '^' {
+		pattern = `^` + pattern
+	}
+	if pattern[len(pattern)-1] != '$' {
+		pattern += `$`
+	}
+
 	for _, f := range s.MutationType.Fields {
 		if found, _ := regexp.MatchString(pattern, f.Name); found {
 			ret = append(ret, f)

--- a/internal/schema/schema_test.go
+++ b/internal/schema/schema_test.go
@@ -310,6 +310,12 @@ func TestSchema_GetQueryStringForMutation_Pattern(t *testing.T) {
 			Name:               "edge.*",
 			MaxQueryFieldDepth: 3,
 		},
+		{
+			Name: "dashboardCreate",
+		},
+		{
+			Name: "^dashboardUpdate$",
+		},
 	}
 
 	for _, tc := range cases {

--- a/internal/schema/testdata/TestSchema_GetQueryStringForMutation_Pattern_dashboardCreate.txt
+++ b/internal/schema/testdata/TestSchema_GetQueryStringForMutation_Pattern_dashboardCreate.txt
@@ -1,0 +1,9 @@
+mutation(
+	$accountId: Int!,
+	$dashboard: DashboardInput!,
+) { dashboardCreate(
+	accountId: $accountId,
+	dashboard: $dashboard,
+) {
+	
+} }

--- a/internal/schema/testdata/TestSchema_GetQueryStringForMutation_Pattern_dashboardUpdate.txt
+++ b/internal/schema/testdata/TestSchema_GetQueryStringForMutation_Pattern_dashboardUpdate.txt
@@ -1,0 +1,9 @@
+mutation(
+	$dashboard: DashboardInput!,
+	$guid: EntityGuid!,
+) { dashboardUpdate(
+	dashboard: $dashboard,
+	guid: $guid,
+) {
+	
+} }


### PR DESCRIPTION
`regexp.MatchString` does not explicitly anchor the regexp, so `asdf` matches `asdffoobar` which breaks existing behavior.

* Explicitly add `^` and `$` to the pattern