### PR TITLE
fix(typegen): do not use `omitempty` in json tags for boolean values

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/fsnotify/fsnotify v1.5.4 // indirect
 	github.com/google/uuid v1.1.2 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
-	github.com/imdario/mergo v0.3.11 // indirect
+	github.com/imdario/mergo v0.3.12 // indirect
 	github.com/inconshreveable/mousetrap v1.0.1 // indirect
 	github.com/magiconair/properties v1.8.6 // indirect
 	github.com/mitchellh/copystructure v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -134,8 +134,9 @@ github.com/huandu/xstrings v1.3.2 h1:L18LIDzqlW6xN2rEkpdV8+oL/IXWJ1APd+vsdYy4Wdw
 github.com/huandu/xstrings v1.3.2/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
-github.com/imdario/mergo v0.3.11 h1:3tnifQM4i+fbajXKBHXWEH+KvNHqojZ778UH75j3bGA=
 github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
+github.com/imdario/mergo v0.3.12 h1:b6R2BslTbIEToALKP7LxUvijTsNI9TAe80pLWN2g/HU=
+github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/inconshreveable/mousetrap v1.0.1 h1:U3uMjPSQEBMNp1lFxmllqCPM6P5u/Xq7Pgzkat/bFNc=
 github.com/inconshreveable/mousetrap v1.0.1/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=

--- a/internal/schema/field.go
+++ b/internal/schema/field.go
@@ -99,8 +99,10 @@ func (f *Field) buildStructTags(fieldName string, structTags []string) string {
 
 		tagsString = tagsString + tagType + ":\"" + f.Name
 
-		if f.Type.IsInputObject() || !f.Type.IsNonNull() {
-			tagsString = tagsString + ",omitempty"
+		if !f.IsBoolean() {
+			if f.Type.IsInputObject() || !f.Type.IsNonNull() {
+				tagsString = tagsString + ",omitempty"
+			}
 		}
 
 		tagsString = tagsString + tagEnd
@@ -120,17 +122,13 @@ func (f *Field) GetTags() string {
 
 	jsonTag := "`json:\"" + f.Name
 
-	if f.Type.IsInputObject() || !f.Type.IsNonNull() {
-		jsonTag += ",omitempty"
+	if !f.IsBoolean() {
+		if f.Type.IsInputObject() || !f.Type.IsNonNull() {
+			jsonTag += ",omitempty"
+		}
 	}
 
 	tags := jsonTag + "\"`"
-
-	// log.Print("\n\n **************************** \n")
-	// log.Printf("\n Struct Tags:  %s \n", f)
-	// log.Printf("\n Struct Tags:  %s \n", jsonTag)
-	// log.Print("\n **************************** \n\n")
-	// time.Sleep(5 * time.Second)
 
 	return tags
 }
@@ -180,4 +178,8 @@ func (f *Field) HasRequiredArg() bool {
 	}
 
 	return false
+}
+
+func (f *Field) IsBoolean() bool {
+	return f.Type.IsBoolean()
 }

--- a/internal/schema/typeref.go
+++ b/internal/schema/typeref.go
@@ -171,3 +171,7 @@ func (r *TypeRef) IsInterface() bool {
 
 	return false
 }
+
+func (r *TypeRef) IsBoolean() bool {
+	return strings.EqualFold("boolean", r.GetTypeName())
+}


### PR DESCRIPTION
In some API scenarios, omitting a `false` value from serialized JSON causes the field to be ignored by the API. By removing `omitempty` from the JSON tags, this ensures a boolean value is always present. 

Related to [newrelic/newrelic-client-go #959](https://github.com/newrelic/newrelic-client-go/pull/959)