### PR TITLE
feat(typegen): support generating fields as pointers, including liss/slices

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -145,6 +145,8 @@ type TypeConfig struct {
 	GenerateStructGetters bool `yaml:"generate_struct_getters,omitempty"`
 	// Applies to all fields of the struct
 	StructTags []string `yaml:"struct_tags,omitempty"`
+	// Defines the fields that should be pointers
+	CreateAsPointer bool `yaml:"create_as_pointer,omitempty"`
 }
 
 const (

--- a/internal/schema/field.go
+++ b/internal/schema/field.go
@@ -67,6 +67,19 @@ func (f *Field) GetName() string {
 	return formatGoName(f.Name)
 }
 
+func (f *Field) HasPointerOverride(pkgConfig *config.PackageConfig) bool {
+	var hasPointerOverride bool
+
+	nameToMatch := f.Type.GetTypeName()
+	for _, p := range pkgConfig.Types {
+		if p.Name == nameToMatch {
+			hasPointerOverride = p.CreateAsPointer
+		}
+	}
+
+	return hasPointerOverride
+}
+
 func (f *Field) GetTagsWithOverrides(parentType Type, pkgConfig *config.PackageConfig) string {
 	if f == nil {
 		return ""

--- a/pkg/lang/golang.go
+++ b/pkg/lang/golang.go
@@ -396,10 +396,14 @@ func getStructField(f schema.Field, pkgConfig *config.PackageConfig, parentType 
 		log.Error(err)
 	}
 
+	if f.HasPointerOverride(pkgConfig) {
+		typeNamePrefix = "*"
+	}
+
 	// In the case we have a LIST type, we need to prefix the type with the slice
 	// descriptor.
 	if f.Type.IsList() {
-		typeNamePrefix = "[]"
+		typeNamePrefix = fmt.Sprintf("%s%s", typeNamePrefix, "[]")
 		isList = true
 	}
 


### PR DESCRIPTION
⚠️ **WIP:** Early POC ⚠️ 

Adds support for always prepending `*` for a struct field type, especially in the case of lists. We currently don't support this functionality for lists. In the example below, the destination configurations are optional, so we would want to omit empty and use a pointer for JSON serialization.

e.g. 

```yaml
    - name: AiWorkflowsDestinationConfigurationInput
      create_as_pointer: true
```

Would result in the following generated struct field: 

```go
type AiWorkflowsCreateWorkflowInput struct {
	DestinationConfigurations *[]AiWorkflowsDestinationConfigurationInput `json:"destinationConfigurations,omitempty"`
  // ...
```

