### PR TITLE
fix(release): remove `archives.replacements`, replace with `archives.name_template`

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -29,12 +29,13 @@ archives:
   - id: "default"
     builds:
       - newrelic
-    replacements:
-      darwin: Darwin
-      linux: Linux
-      windows: Windows
-      386: i386
-      amd64: x86_64
+    name_template: >-
+      {{- .ProjectName }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
+      {{- if .Arm }}v{{ .Arm }}{{ end -}}
     format_overrides:
       - goos: windows
         format: zip


### PR DESCRIPTION
GoReleaser removed `archives.replacements` in the version we're using in this repo and [this is the workaround](https://goreleaser.com/deprecations/#archivesreplacements) mentioned in the GoReleaser docs.